### PR TITLE
Featureparity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: julia
+julia:
+  - nightly

--- a/src/01_typedefs.jl
+++ b/src/01_typedefs.jl
@@ -22,12 +22,12 @@ immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
     isnull::Array{Bool, N}
     values::Array{T, N}
 
-    function NullableArray(m::Array{Bool, N}, d::Array{T, N})
+    function NullableArray(m::Array{Bool, N}, d::AbstractArray{T, N})
         if size(d) != size(m)
             msg = "values and missingness arrays must be the same size"
             throw(ArgumentError(msg))
         end
-        new{T, N}(m, d)
+        new(m, d)
     end
 end
 

--- a/src/01_typedefs.jl
+++ b/src/01_typedefs.jl
@@ -21,6 +21,14 @@ reusing operations that only work on arrays without any null values.
 immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
     isnull::Array{Bool, N}
     values::Array{T, N}
+
+    function NullableArray(m::Array{Bool, N}, d::Array{T, N})
+        if size(d) != size(m)
+            msg = "values and missingness arrays must be the same size"
+            throw(ArgumentError(msg))
+        end
+        new{T, N}(m, d)
+    end
 end
 
 typealias NullableVector{T} NullableArray{T, 1}

--- a/src/01_typedefs.jl
+++ b/src/01_typedefs.jl
@@ -19,15 +19,15 @@ It allows users to easily define operations on arrays with null values by
 reusing operations that only work on arrays without any null values.
 """ ->
 immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
-    isnull::Array{Bool, N}
     values::Array{T, N}
+    isnull::Array{Bool, N}
 
-    function NullableArray(m::Array{Bool, N}, d::AbstractArray{T, N})
+    function NullableArray(d::AbstractArray{T, N}, m::Array{Bool, N})
         if size(d) != size(m)
             msg = "values and missingness arrays must be the same size"
             throw(ArgumentError(msg))
         end
-        new(m, d)
+        new(d, m)
     end
 end
 

--- a/src/02_constructors.jl
+++ b/src/02_constructors.jl
@@ -4,8 +4,8 @@
 # The following allows for construction of a NullableArray without explicit
 # specification of type parameters;
 # see docs.julialang.org/en/latest/manual/constructors/#parametric-constructors
-function NullableArray(m::AbstractArray, a::AbstractArray) # -> NullableArray
-    return NullableArray{eltype(a), ndims(a)}(m, a)
+function NullableArray{T, N}(m::Array{Bool, N}, a::AbstractArray{T, N}) # -> NullableArray
+    return NullableArray{T, N}(m, a)
 end
 
 # TODO: Uncomment this doc entry when Base Julia can parse it correctly.
@@ -36,4 +36,36 @@ end
 # 'false's the size of 'a'.
 function NullableArray{T, N}(a::AbstractArray{T, N}) # -> NullableArray
     return NullableArray{T, N}(fill(false, size(a)), a)
+end
+
+# The following method constructs a NullableArray from an Array{Any} argument
+# 'A' that contains some placeholder of type 'T' for null values.
+#
+# e.g.: julia> NullableArray([1, nothing, 2], Void)
+#       3-element NullableArrays.NullableArray{Int64,1}:
+#       Nullable(1)
+#       Nullable{Int64}()
+#       Nullable(2)
+#
+#       julia> NullableArray([1, "notdefined", 2], ASCIIString)
+#       3-element NullableArrays.NullableArray{Int64,1}:
+#       Nullable(1)
+#       Nullable{Int64}()
+#       Nullable(2)
+#
+# TODO: think about dispatching on T = Any in method above to call
+# the following method passing 'T=Void' for pseudo-literal
+# NullableArray construction
+function NullableArray{T, U}(A::Array, ::Type{T}, ::Type{U})
+    _isnull = fill(true, size(A))
+    _values = Array(T, size(A))
+    @inbounds for (i, value) in enumerate(A)
+        if !isa(value, U)
+            setindex!(_isnull, false, i)
+        end
+    end
+    @inbounds for (i, isnull) in enumerate(_isnull)
+        !isnull && setindex!(_values, A[i], i)
+    end
+    return NullableArray(_isnull, _values)
 end

--- a/src/02_constructors.jl
+++ b/src/02_constructors.jl
@@ -4,8 +4,8 @@
 # The following allows for construction of a NullableArray without explicit
 # specification of type parameters;
 # see docs.julialang.org/en/latest/manual/constructors/#parametric-constructors
-function NullableArray{T, N}(m::Array{Bool, N}, a::AbstractArray{T, N}) # -> NullableArray
-    return NullableArray{T, N}(m, a)
+function NullableArray{T, N}(A::AbstractArray{T, N}, m::Array{Bool, N}) # -> NullableArray
+    return NullableArray{T, N}(A, m)
 end
 
 # TODO: Uncomment this doc entry when Base Julia can parse it correctly.
@@ -21,7 +21,7 @@ end
 # `NullableArray` a null value by default.
 # """ ->
 function NullableArray{T}(::Type{T}, dims::Dims) # -> NullableArray
-    return NullableArray(fill(true, dims), Array(T, dims))
+    return NullableArray(Array(T, dims), fill(true, dims))
 end
 
 # Constructs an empty NullableArray of type parameter T and number of dimensions
@@ -34,8 +34,8 @@ end
 # Constructs a NullableArray from an Array 'a' of values and an optional
 # Array{Bool, N} mask. If omitted, the mask will default to an array of
 # 'false's the size of 'a'.
-function NullableArray{T, N}(a::AbstractArray{T, N}) # -> NullableArray
-    return NullableArray{T, N}(fill(false, size(a)), a)
+function NullableArray{T, N}(A::AbstractArray{T, N}) # -> NullableArray
+    return NullableArray{T, N}(A, fill(false, size(A)))
 end
 
 # The following method constructs a NullableArray from an Array{Any} argument

--- a/src/02_constructors.jl
+++ b/src/02_constructors.jl
@@ -2,8 +2,8 @@
 # ----- Constructors -------------------------------------------------------- #
 
 # The following allows for construction of a NullableArray without explicit
-# specification of type parameters.
-# See docs.julialang.org/en/latest/manual/constructors/#parametric-constructors
+# specification of type parameters;
+# see docs.julialang.org/en/latest/manual/constructors/#parametric-constructors
 function NullableArray(m::AbstractArray, a::AbstractArray) # -> NullableArray
     return NullableArray{eltype(a), ndims(a)}(m, a)
 end
@@ -34,9 +34,6 @@ end
 # Constructs a NullableArray from an Array 'a' of values and an optional
 # Array{Bool, N} mask. If omitted, the mask will default to an array of
 # 'false's the size of 'a'.
-function NullableArray{T, N}(
-    a::AbstractArray{T, N},
-    m::Array{Bool,N} = fill(false, size(a))
-) # -> NullableArray
-    return NullableArray(m, a)
+function NullableArray{T, N}(a::AbstractArray{T, N}) # -> NullableArray
+    return NullableArray{T, N}(fill(false, size(a)), a)
 end

--- a/src/02_constructors.jl
+++ b/src/02_constructors.jl
@@ -1,3 +1,13 @@
+
+# ----- Constructors -------------------------------------------------------- #
+
+# The following allows for construction of a NullableArray without explicit
+# specification of type parameters.
+# See docs.julialang.org/en/latest/manual/constructors/#parametric-constructors
+function NullableArray(m::AbstractArray, a::AbstractArray) # -> NullableArray
+    return NullableArray{eltype(a), ndims(a)}(m, a)
+end
+
 # TODO: Uncomment this doc entry when Base Julia can parse it correctly.
 # @doc """
 # Allow users to construct a quasi-uninitialized `NullableArray` object by
@@ -10,9 +20,23 @@
 # will be initialized to `true` everywhere, making every entry of a new
 # `NullableArray` a null value by default.
 # """ ->
-function NullableArray{T}(::Type{T}, dims::Dims)
-    NullableArray(
-        fill(true, dims),
-        Array(T, dims),
-    )
+function NullableArray{T}(::Type{T}, dims::Dims) # -> NullableArray
+    return NullableArray(fill(true, dims), Array(T, dims))
+end
+
+# Constructs an empty NullableArray of type parameter T and number of dimensions
+# equal to the number of arguments given in 'dims...', where the latter are
+# dimension lengths.
+function NullableArray(T::Type, dims::Int...) # -> NullableArray
+    return NullableArray(T, dims)
+end
+
+# Constructs a NullableArray from an Array 'a' of values and an optional
+# Array{Bool, N} mask. If omitted, the mask will default to an array of
+# 'false's the size of 'a'.
+function NullableArray{T, N}(
+    a::AbstractArray{T, N},
+    m::Array{Bool,N} = fill(false, size(a))
+) # -> NullableArray
+    return NullableArray(m, a)
 end

--- a/src/03_primitives.jl
+++ b/src/03_primitives.jl
@@ -1,6 +1,10 @@
+# ----- Base.size
+
 # We determine the size of a NullableArray array using the size of its
 # `values` field. We could equivalently use the `.isnull` field.
-Base.size(X::NullableArray) = size(X.values)
+Base.size(X::NullableArray) = size(X.values) # -> NTuple{Int}
+
+# ----- Base.similar ---------------------------------------------------------#
 
 # Allocate a similar array
 function Base.similar{T <: Nullable}(X::NullableArray, ::Type{T}, dims::Dims)
@@ -22,7 +26,7 @@ function Base.copy!(dest::NullableArray, src::NullableArray) # -> NullableArray
         copy!(dest.values, src.values)
     else
         dest_values = dest.values
-        src_values = src_values
+        src_values = src.values
         length(dest_values) >= length(src_values) || throw(BoundsError())
         # Copy only initilialized values from src into dest
         # TODO: investigate "BoolArray.chunks"
@@ -31,70 +35,160 @@ function Base.copy!(dest::NullableArray, src::NullableArray) # -> NullableArray
         end
     end
     copy!(dest.isnull, src.isnull)
+    return dest
 end
 
 # ----- Base.fill! -----------------------------------------------------------#
 
-function Base.fill!(A::NullableArray, x::Nullable)
+function Base.fill!(X::NullableArray, x::Nullable) # -> NullableArray{T, N}
     if isnull(x)
-        fill!(A.isnull, true)
+        fill!(X.isnull, true)
     else
-        fill!(A.values, get(x))
-        fill!(A.isnull, false)
+        fill!(X.values, get(x))
+        fill!(X.isnull, false)
     end
-    return A
+    return X
 end
 
-function Base.fill!(A::NullableArray, x::Any)
-    fill!(A.values, x)
-    fill!(A.isnull, false)
-    return A
+function Base.fill!(X::NullableArray, x::Any) # -> NullableArray{T, N}
+    fill!(X.values, x)
+    fill!(X.isnull, false)
+    return X
 end
 
 # ----- Base.deepcopy ------------
 
-function Base.deepcopy(d::NullableArray) # -> NullableArray{T}
-    return NullableArray(deepcopy(d.values), deepcopy(d.isnull))
+function Base.deepcopy(X::NullableArray) # -> NullableArray{T}
+    return NullableArray(deepcopy(X.values), deepcopy(X.isnull))
 end
-
-# ----- Base.size
-
-
 
 # ----- Base.resize!
 
+function Base.resize!{T}(X::NullableArray{T,1}, n::Int) # -> NullableArray{T, N}
+    resize!(X.values, n)
+    oldn = length(X.isnull)
+    resize!(X.isnull, n)
+    X.isnull[oldn+1:n] = true
+    return X
+end
 
 # ----- Base.ndims
 
+Base.ndims(X::NullableArray) = ndims(X.values) # -> Int
 
 # ----- Base.length
 
+Base.length(X::NullableArray) = length(X.values) # -> Int
 
 # ----- Base.endof
 
+Base.endof(X::NullableArray) = endof(X.values) # -> Int
 
 # ----- Base.find
 
+function Base.find(X::NullableArray{Bool}) # -> Array{Int}
+    ntrue = 0
+    @inbounds for (i, isnull) in enumerate(X.isnull)
+        ntrue += !isnull && X.values[i]
+    end
+    target = Array(Int, ntrue)
+    ind = 1
+    @inbounds for (i, isnull) in enumerate(X.isnull)
+        if !isnull && X.values[i]
+            target[ind] = i
+            ind += 1
+        end
+    end
+    return target
+end
+
+# TODO: implement further 'find' methods
 
 # ----- dropnull
 
+dropnull(X::NullableVector) = copy(X.values[!X.isnull]) # -> Vector
 
-# ----- isnull
+# ----- Base.isnull
 
+Base.isnull(X::NullableArray) = copy(X.isnull)
+
+Base.isnull(X::NullableArray, i::Integer) = X.isnull[i]
+
+#DataArray defined nsplat macro version isna, punting for now pending questions
 
 # ----- anynull
 
+anynull(X::NullableArray) = any(X.isnull) # -> Bool
 
 # ----- allnull
 
+allnull(X::NullableArray) = all(X.isnull) # -> Bool
 
 # ----- Base.isnan
 
+function Base.isnan(X::NullableArray) # -> NullableArray{Bool}
+    return NullableArray(isnan(X.values), copy(X.isnull))
+end
 
 # ----- Base.isfinite
 
+function Base.isfinite(X::NullableArray) # -> NullableArray{Bool}
+    n = length(X)
+    target = Array(Bool, size(X))
+    for i in 1:n
+        if !X.isnull[i]
+            target[i] = isfinite(X.values[i])
+        end
+    end
+    return NullableArray(target, copy(X.isnull))
+end
 
 # ----- Base.convert
+
+function Base.convert{S, T, N}(::Type{Array{S, N}},
+                               X::NullableArray{T, N}) # -> Array{S, N}
+    if anynull(X)
+        err = "Cannot convert NullableArray with null values."
+        throw(NullException(err))
+    else
+        return convert(Array{S, N}, X.values)
+    end
+end
+
+function Base.convert{S, T, N}(::Type{Array{S}},
+                               X::NullableArray{T, N}) # -> Array{S, N}
+    return convert(Array{S, N}, X)
+end
+
+function Base.convert{T}(::Type{Vector}, X::NullableVector{T}) # -> Vector{T}
+    return convert(Array{T, 1}, X)
+end
+
+function Base.convert{T}(::Type{Matrix}, X::NullableMatrix{T}) # -> Matrix{T}
+    return convert(Array{T, 2}, X)
+end
+
+function Base.convert{T, N}(::Type{Array},
+                            X::NullableArray{T, N}) # -> Array{T, N}
+    return convert(Array{T, N}, X)
+end
+
+function Base.convert{S, T, N}(
+    ::Type{Array{S, N}},
+    X::NullableArray{T, N},
+    replacement::Any
+) # -> Array{S, N}
+    replacementS = convert(S, replacement)
+    target = Array(S, size(X))
+    for i in 1:length(X)
+        if X.isnull[i]
+            target[i] = replacementS
+        else
+            target[i] = X.values[i]
+        end
+    end
+    return target
+end
 
 
 # ----- Base.promote

--- a/src/03_primitives.jl
+++ b/src/03_primitives.jl
@@ -9,3 +9,104 @@ end
 
 # Allocate a similar array
 Base.similar(X::NullableArray, T, dims::Dims) = NullableArray(T, dims)
+
+# ----- Base.copy/copy! ------------------------------------------------------#
+
+Base.copy(X::NullableArray) = Base.copy!(similar(X), X)
+
+
+# Copies the initialized values of a source NullableArray into the respective
+# indices of the destination NullableArray.
+function Base.copy!(dest::NullableArray, src::NullableArray) # -> NullableArray
+    if isbits(eltype(dest)) && isbits(eltype(src))
+        copy!(dest.values, src.values)
+    else
+        dest_values = dest.values
+        src_values = src_values
+        length(dest_values) >= length(src_values) || throw(BoundsError())
+        # Copy only initilialized values from src into dest
+        # TODO: investigate "BoolArray.chunks"
+        for i in 1:length(src_values)
+            @inbounds !(src.isnull[i]) && (dest.values[i] = src.values[i])
+        end
+    end
+    copy!(dest.isnull, src.isnull)
+end
+
+# ----- Base.fill! -----------------------------------------------------------#
+
+function Base.fill!(A::NullableArray, x::Nullable)
+    if isnull(x)
+        fill!(A.isnull, true)
+    else
+        fill!(A.values, get(x))
+        fill!(A.isnull, false)
+    end
+    return A
+end
+
+function Base.fill!(A::NullableArray, x::Any)
+    fill!(A.values, x)
+    fill!(A.isnull, false)
+    return A
+end
+
+# ----- Base.deepcopy ------------
+
+function Base.deepcopy(d::NullableArray) # -> NullableArray{T}
+    return NullableArray(deepcopy(d.values), deepcopy(d.isnull))
+end
+
+# ----- Base.size
+
+
+
+# ----- Base.resize!
+
+
+# ----- Base.ndims
+
+
+# ----- Base.length
+
+
+# ----- Base.endof
+
+
+# ----- Base.find
+
+
+# ----- dropnull
+
+
+# ----- isnull
+
+
+# ----- anynull
+
+
+# ----- allnull
+
+
+# ----- Base.isnan
+
+
+# ----- Base.isfinite
+
+
+# ----- Base.convert
+
+
+# ----- Base.promote
+
+
+# ----- Base.hash
+
+
+# ----- finduniques
+
+
+# ----- Base.unique
+
+
+# ----- levels

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -1,5 +1,12 @@
 module NullableArrays
-    export NullableArray, NullableVector, NullableMatrix
+    export NullableArray,
+           NullableVector,
+           NullableMatrix,
+
+           # Methods
+           dropnull,
+           anynull,
+           allnull
 
     include("01_typedefs.jl")
     include("02_constructors.jl")

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -1,12 +1,17 @@
 module NullableArrays
+
+    using  Base.Cartesian
+
     export NullableArray,
            NullableVector,
            NullableMatrix,
 
            # Methods
+           nul,
            dropnull,
            anynull,
-           allnull
+           allnull,
+           levels
 
     include("01_typedefs.jl")
     include("02_constructors.jl")

--- a/test/01_typedefs.jl
+++ b/test/01_typedefs.jl
@@ -3,18 +3,18 @@ module TestTypeDefs
     using NullableArrays
 
     x = NullableArray(
-        [false, false, true],
         [1, 2, 3],
+        [false, false, true]
     )
 
     y = NullableArray(
         [
-            false false;
-            true false;
-        ],
-        [
             1 2;
             3 4;
+        ],
+        [
+            false false;
+            true false;
         ],
     )
 

--- a/test/02_constructors.jl
+++ b/test/02_constructors.jl
@@ -6,7 +6,7 @@ module TestConstructors
     x1 = NullableArray(Int, 5)
     x2 = NullableArray(Int, 5, 2)
     y = NullableArray([1, 2, 3, 4, 5, 6])
-    y2 = NullableArray([true, false, false, false, false ,false], [1, 2, 3, 4, 5, 6])
+    y2 = NullableArray([1, 2, 3, 4, 5, 6], [true, false, false, false, false ,false])
 
     @test isa(x, NullableVector{Int})
     @test isa(x1, NullableVector{Int})
@@ -18,17 +18,17 @@ module TestConstructors
 
 # test if any errors thrown during common constructor use-patterns
     v = [1, 2, 3, 4]
-    dv = NullableArray(fill(false, size(v)), v)
+    dv = NullableArray(v, fill(false, size(v)))
 
     m = [1 2; 3 4]
-    dm = NullableArray(fill(false, size(m)), m)
+    dm = NullableArray(m, fill(false, size(m)))
 
     t = Array(Int, 2, 2, 2)
     t[1:2, 1:2, 1:2] = 1
-    dt = NullableArray(fill(false, size(t)), t)
+    dt = NullableArray(t, fill(false, size(t)))
 
     dv = NullableArray(v)
-    dv = NullableArray([false, false, false, false], v)
+    dv = NullableArray(v, [false, false, false, false])
 
     dv = NullableArray(Int, 2)
     dm = NullableArray(Int, 2, 2)

--- a/test/02_constructors.jl
+++ b/test/02_constructors.jl
@@ -14,4 +14,23 @@ module TestConstructors
     @test isa(y, NullableVector{Int})
     @test isa(y2, NullableVector{Int})
     @test y2.isnull[1]
+
+
+# test if any errors thrown during common constructor use-patterns
+    v = [1, 2, 3, 4]
+    dv = NullableArray(fill(false, size(v)), v)
+
+    m = [1 2; 3 4]
+    dm = NullableArray(fill(false, size(m)), m)
+
+    t = Array(Int, 2, 2, 2)
+    t[1:2, 1:2, 1:2] = 1
+    dt = NullableArray(fill(false, size(t)), t)
+
+    dv = NullableArray(v)
+    dv = NullableArray([false, false, false, false], v)
+
+    dv = NullableArray(Int, 2)
+    dm = NullableArray(Int, 2, 2)
+    dt = NullableArray(Int, 2, 2, 2)
 end

--- a/test/02_constructors.jl
+++ b/test/02_constructors.jl
@@ -6,15 +6,12 @@ module TestConstructors
     x1 = NullableArray(Int, 5)
     x2 = NullableArray(Int, 5, 2)
     y = NullableArray([1, 2, 3, 4, 5, 6])
-    y1 = NullableArray([1, 2, 3, 4, 5, 6], [true, false, false, false, false ,false])
     y2 = NullableArray([true, false, false, false, false ,false], [1, 2, 3, 4, 5, 6])
 
     @test isa(x, NullableVector{Int})
     @test isa(x1, NullableVector{Int})
     @test isa(x2, NullableMatrix{Int})
     @test isa(y, NullableVector{Int})
-    @test isa(y1, NullableVector{Int})
-    @test y1.isnull[1]
     @test isa(y2, NullableVector{Int})
     @test y2.isnull[1]
 end

--- a/test/02_constructors.jl
+++ b/test/02_constructors.jl
@@ -3,6 +3,18 @@ module TestConstructors
     using NullableArrays
 
     x = NullableArray(Int, (5, ))
+    x1 = NullableArray(Int, 5)
+    x2 = NullableArray(Int, 5, 2)
+    y = NullableArray([1, 2, 3, 4, 5, 6])
+    y1 = NullableArray([1, 2, 3, 4, 5, 6], [true, false, false, false, false ,false])
+    y2 = NullableArray([true, false, false, false, false ,false], [1, 2, 3, 4, 5, 6])
 
     @test isa(x, NullableVector{Int})
+    @test isa(x1, NullableVector{Int})
+    @test isa(x2, NullableMatrix{Int})
+    @test isa(y, NullableVector{Int})
+    @test isa(y1, NullableVector{Int})
+    @test y1.isnull[1]
+    @test isa(y2, NullableVector{Int})
+    @test y2.isnull[1]
 end

--- a/test/03_primitives.jl
+++ b/test/03_primitives.jl
@@ -1,6 +1,7 @@
 module TestPrimitives
     using Base.Test
     using NullableArrays
+    # TODO: Organize tests, include references to /src
 
     x = NullableArray(Int, (5, 2))
 
@@ -19,4 +20,107 @@ module TestPrimitives
     @test isa(z, NullableVector{Int})
 
     @test size(z) === (2, )
+
+    macro nullable(vec)
+        e_array = Expr(:vect)
+        e_mask = Expr(:vect)
+        e_target = Expr(:call, :NullableArray)
+        for (i, arg) in enumerate(vec.args)
+            if arg == :nothing
+                push!(e_mask.args, true)
+                push!(e_array.args, 0)
+            else
+                push!(e_mask.args, false)
+                push!(e_array.args, arg)
+            end
+        end
+        push!(e_target.args, e_mask, e_array)
+        return e_target
+    end
+
+    v = [1, 2, 3, 4]
+    dv = NullableArray(fill(false, size(v)), v)
+
+    m = [1 2; 3 4]
+    dm = NullableArray(fill(false, size(m)), m)
+
+    t = Array(Int, 2, 2, 2)
+    t[1:2, 1:2, 1:2] = 1
+    dt = NullableArray(fill(false, size(t)), t)
+
+    dv = NullableArray(v)
+    dv = NullableArray([false, false, false, false], v)
+
+    dv = NullableArray(Int, 2)
+    dm = NullableArray(Int, 2, 2)
+    dt = NullableArray(Int, 2, 2, 2)
+
+    similar(dv)
+    similar(dm)
+    similar(dt)
+
+    similar(dv, 2)
+    similar(dm, 2, 2)
+    similar(dt, 2, 2, 2)
+
+    x = @nullable [1, 2, nothing]
+    y = @nullable [3, nothing, 5]
+    @test isequal(copy(x), x)
+    @test isequal(copy!(y, x), x)
+
+    x = @nullable [1, nothing, -2, 1, nothing, 4]
+    @assert isequal(unique(x), @nullable [1, nothing, -2, 4])
+    @assert isequal(unique(reverse(x)), @nullable [4, nothing, 1, -2])
+
+    # check case where only nothing occurs in final position
+    @assert isequal(unique(@nullable [1, 2, 1, nothing]), @nullable [1, 2, nothing])
+
+    # Test copy!
+    function nonbits(dv)
+        ret = similar(dv, Integer)
+        for i = 1:length(dv)
+            if !isnull(dv, i)
+                ret[i] = dv[i]
+            end
+        end
+        ret
+    end
+    set1 = Any[@nullable([1, nothing, 3]),
+               @nullable([nothing, 5]), @nullable([1, 2, 3, 4, 5]), NullableArray(Int[]),
+               @nullable([nothing, 5, 3]), @nullable([1, 5, 3])]
+    set2 = map(nonbits, set1)
+
+    for (dest, src, bigsrc, emptysrc, res1, res2) in Any[set1, set2]
+        # Base.copy! was inconsistent until recently in 0.4-dev
+        da_or_04 = VERSION > v"0.4-"
+
+        @test isequal(copy!(copy(dest), src), res1)
+        @test isequal(copy!(copy(dest), 1, src), res1)
+
+        da_or_04 && @test isequal(copy!(copy(dest), 2, src, 2), res2)
+        @test isequal(copy!(copy(dest), 2, src, 2, 1), res2)
+
+        @test isequal(copy!(copy(dest), 99, src, 99, 0), dest)
+
+        @test isequal(copy!(copy(dest), 1, emptysrc), dest)
+        da_or_04 && @test_throws BoundsError copy!(dest, 1, emptysrc, 1)
+
+        for idx in [0, 4]
+            @test_throws BoundsError copy!(dest, idx, src)
+            @test_throws BoundsError copy!(dest, idx, src, 1)
+            @test_throws BoundsError copy!(dest, idx, src, 1, 1)
+            @test_throws BoundsError copy!(dest, 1, src, idx)
+            @test_throws BoundsError copy!(dest, 1, src, idx, 1)
+        end
+
+       da_or_04 && @test_throws BoundsError copy!(dest, 1, src, 1, -1)
+
+        @test_throws BoundsError copy!(dest, bigsrc)
+
+        @test_throws BoundsError copy!(dest, 3, src)
+        @test_throws BoundsError copy!(dest, 3, src, 1)
+        @test_throws BoundsError copy!(dest, 3, src, 1, 2)
+        @test_throws BoundsError copy!(dest, 1, src, 2, 2)
+    end
+
 end

--- a/test/03_primitives.jl
+++ b/test/03_primitives.jl
@@ -20,7 +20,7 @@ macro nullable(vec)
             push!(e_array.args, arg)
         end
     end
-    push!(e_target.args, e_mask, e_array)
+    push!(e_target.args, e_array, e_mask)
     return e_target
 end
 


### PR DESCRIPTION
This PR:
1. Adds analogous methods for the most of the primitives found in DataArrays/src/dataarray.jl
2. Ports a number of tests from DataArrays/test/dataarray.jl, though does not contain complete coverage
3. Adds an inner constructor that checks that the lengths of the `isnull` and `values` fields are equal
4. Adds outer constructors analogous to those of DataArrays, plus a new outer constructor whose purpose is similar to that of the `@data` macro.

I promise all future PRs will only involve self-contained revisions/additions... >_>
