### PR TITLE
Remove levels (TBF in separate package)

### DIFF
--- a/src/03_primitives.jl
+++ b/src/03_primitives.jl
@@ -253,7 +253,7 @@ end
 # Use ready-made method for AbstractArrays or implement method specific to
 # NullableArrays, possibly for performance purposes?
 
-# ----- levels ---------------------------------------------------------------#
-function levels(a::AbstractArray) # -> Vector{T}
-    return unique(a)
-end
+# ----- Base.reverse ---------------------------------------------------------#
+
+# Use ready-made method for AbstractArrays or implement method specific to
+# NullableArrays, possibly for performance purposes?


### PR DESCRIPTION
This PR removes the 'levels' method from src/03_primitives.jl. It also adds a little note about the 'reverse' method, which `NullableArray` currently inherits from `AbstractArray` in an attempt to keep track of inheritance and also record notes about possibilities for performance improvements with specialized methods.
