### PR TITLE
Indexing

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -10,7 +10,7 @@ module NullableArrays
            dropnull,
            anynull,
            allnull,
-           levels
+           nullify
 
     include("01_typedefs.jl")
     include("02_constructors.jl")

--- a/test/04_indexing.jl
+++ b/test/04_indexing.jl
@@ -23,4 +23,113 @@ module TestIndexing
         @test isa(y, Nullable{Int})
         @test isnull(y)
     end
+
+    _values = rand(10, 10)
+    _isnull = rand(Bool, 10, 10)
+    X = NullableArray(_values, _isnull)
+
+    # Scalar getindex
+    for i = 1:100
+        if _isnull[i]
+            @test isnull(X[i])
+        else
+            @test isequal(X[i], Nullable(_values[i]))
+        end
+    end
+    for i = 1:10, j = 1:10
+        if _isnull[i, j]
+            @test isnull(X[i, j])
+        else
+            @test isequal(X[i, j], Nullable(_values[i, j]))
+        end
+    end
+
+    # getindex with AbstractVectors
+    rg = 2:9
+    v = X[rg]
+    for i = 1:length(rg)
+        if _isnull[rg[i]]
+            @test isnull(v[i])
+        else
+            @test isequal(v[i], Nullable(_values[rg[i]]))
+        end
+    end
+
+    v = X[rg, 9]
+    for i = 1:length(rg)
+        if _isnull[rg[i], 9]
+            @test isnull(v[i])
+        else
+            @test isequal(v[i], Nullable(_values[rg[i], 9]))
+        end
+    end
+
+    rg2 = 5:7
+    v = X[rg, rg2]
+    for j = 1:length(rg2), i = 1:length(rg)
+        if _isnull[rg[i], rg2[j]]
+            @test isnull(v[i, j])
+        else
+            @test isequal(v[i, j], Nullable(_values[rg[i], rg2[j]]))
+        end
+    end
+
+    # getindex with AbstractVector{Bool}
+    b = bitrand(10, 10)
+    rg = find(b)
+    v = X[b]
+    for i = 1:length(rg)
+        if _isnull[rg[i]]
+            @test isnull(v[i])
+        else
+            @test isequal(v[i], Nullable(_values[rg[i]]))
+        end
+    end
+
+    # getindex with valuesVectors with missingness throws
+    @test_throws NullException X[NullableArray([1, 2, 3, nothing], Int, Void)]
+
+    # setindex! with scalar indices
+    _values = rand(10, 10)
+    for i = 1:100
+        X[i] = _values[i]
+    end
+    @test isequal(X, NullableArray(_values))
+
+    _values = rand(10, 10)
+    for i = 1:10, j = 1:10
+        X[i, j] = _values[i, j]
+    end
+    @test isequal(X, NullableArray(_values))
+
+# ----- test nullify -----#
+    _isnull = bitrand(10, 10)
+    for i = 1:100
+        _isnull[i] && (nullify(X, i))
+    end
+
+    # setindex! with scalar and vector indices
+    rg = 2:9
+    _values[rg] = 1.0
+    X[rg] = 1.0
+    for i = 1:length(rg)
+        @test isequal(X[rg[i]], Nullable(1.0))
+    end
+
+    # setindex! with NA and vector indices
+    rg = 5:13
+    _isnull[rg] = true
+    nullify(X, rg)
+    for i = 1:length(rg)
+        @test isnull(X[rg[i]])
+    end
+
+    # setindex! with vector and vector indices
+    rg = 12:67
+    _values[rg] = rand(length(rg))
+    X[rg] = _values[rg]
+    for i = 1:length(rg)
+        @test isequal(X[rg[i]], Nullable(_values[rg[i]]))
+    end
+
 end


### PR DESCRIPTION
This PR:

-adds `Base._checkbounds` and `Base.to_index` methods to better take advantage of the `AbstractArray` indexing regime 
-includes a `nullify` method to set a null index for a `NullableArray` 
-includes two unsafe indexing methods for `NullableArray`s
-includes indexing-related tests ported from the `DataArrays` testing suite.
