### PR TITLE
Add 'Base.map!/Base.map' plus tests

### DIFF
--- a/src/05_map.jl
+++ b/src/05_map.jl
@@ -1,0 +1,175 @@
+
+using Base: ith_all
+
+#----- Base.map!/Base.map ----------------------------------------------------#
+
+# 1 arg
+function Base.map!{F}(f::F,
+                      dest::NullableArray,
+                      A::AbstractArray) # -> NullableArray{T, N}
+    _f = Expr(:quote, f)
+    @eval begin
+        local func
+        function func(dest, A)
+            for i in 1:length(dest)
+                dest[i] = ($_f)(A[i])
+            end
+        end
+        func($dest, $A)
+        $dest
+    end
+end
+
+function map_to!{T, F}(f::F,
+                       offs,
+                       dest::NullableArray{T},
+                       A::AbstractArray) # -> NullableArray{T, N}
+    _f = Expr(:quote, f)
+    @eval begin
+        local func
+        function func{T}(offs, dest::NullableArray{T}, A)
+            @inbounds for i in offs:length(A)
+                el = $_f(A[i])
+                S = typeof(el)
+                if S === T || S <: T
+                    dest[i] = el::T
+                else
+                    R = typejoin(T, S)
+                    new = similar(dest, R)
+                    copy!(new, 1, dest, 1, i - 1)
+                    new[i] = el
+                    return func(i+1, new, A)
+                end
+            end
+            return dest
+        end
+        func($offs, $dest, $A)
+    end
+end
+
+function Base.map(f, X::NullableArray) # -> NullableArray{T, N}
+    if isempty(X)
+        return isa(f, Type) ? similar(X, f) : similar(X)
+    else
+        first = f(X[1])
+        dest = similar(X, typeof(first))
+        dest[1] = first
+        return map_to!(f, 2, dest, X)
+    end
+end
+
+# 2 arg
+function Base.map!{F}(f::F,
+                      dest::NullableArray,
+                      A::AbstractArray,
+                      B::AbstractArray) # -> NullableArray{T, N}
+    _f = Expr(:quote, f)
+    @eval begin
+        local func =
+        function func(dest, A, B)
+            for i in 1:length(dest)
+                dest[i] = $_f(A[i], B[i])
+            end
+        end
+        func($dest, $A, $B)
+        $dest
+    end
+end
+
+function map_to!{T, F}(f::F, offs,
+                       dest::NullableArray{T},
+                       A::AbstractArray,
+                       B::AbstractArray) # -> NullableArray{T, N}
+    _f = Expr(:quote, f)
+    @eval begin
+        local func
+        function func{T}(offs, dest::NullableArray{T}, A, B)
+            @inbounds for i in offs:length(A)
+                el = $_f(A[i], B[i])
+                # println(el)
+                S = typeof(el)
+                # println(S)
+                if S !== T && !(S <: T)
+                    R = typejoin(T, S)
+                    new = similar(dest, R)
+                    copy!(new, 1, dest, 1, i - 1)
+                    new[i] = el
+                    return func(i+1, new, A, B)
+                end
+                dest[i] = el::T
+            end
+            return dest
+        end
+        func($offs, $dest, $A, $B)
+    end
+end
+
+function Base.map(f, X::NullableArray, Y::NullableArray) # -> NullableArray{T, N}
+    shape = promote_shape(size(X), size(Y))
+    if prod(shape) == 0
+        return similar(X, promote_type(eltype(X), eltype(Y)), shape)
+    else
+        first = f(X[1], f(Y[1]))
+        dest = similar(X, typeof(first))
+        # dest[1] = first
+        return map_to!(f, 1, dest, X, Y)
+    end
+end
+
+# N-args
+function map_n!{F}(f::F,
+                      dest::NullableArray,
+                      As) # -> NullableArray{T, N}
+    _f = Expr(:quote, f)
+    @eval begin
+        local func
+        function func(dest, As)
+            for i in 1:length(dest)
+                dest[i] = $_f(ith_all(i, As)...)
+            end
+        end
+        func($dest, $As)
+        $dest
+    end
+end
+
+function Base.map!{F}(f::F, dest::NullableArray, As::AbstractArray...)
+    return map_n!(f, dest, As)
+end
+
+function map_to_n!{T, F}(f::F, offs,
+                       dest::NullableArray{T},
+                       As) # -> NullableArray{T, N}
+    _f = Expr(:quote, f)
+    @eval begin
+        local func
+        function func{T}(offs, dest::NullableArray{T}, As)
+            @inbounds for i in offs:length(As[1])
+                el = $_f(ith_all(i, As)...)
+                S = typeof(el)
+                if S !== T && !(S <: T)
+                    R = typejoin(T, S)
+                    new = similar(dest, R)
+                    copy!(new, 1, dest, 1, i - 1)
+                    new[i] = el
+                    return func(i+1, new, As)
+                end
+                dest[i] = el::T
+            end
+            return dest
+        end
+        func($offs, $dest, $As)
+    end
+end
+
+function Base.map(f, Xs::NullableArray...) # -> NullableArray{T, N}
+    shape = mapreduce(size, promote_shape, Xs)
+    if prod(shape) == 0
+        return similar(X[1], promote_type(Xs...), shape)
+    else
+        first = f(ith_all(1, Xs)...)
+        dest = similar(Xs[1], typeof(first), shape)
+        dest[1] = first
+        return map_to_n!(f, 1, dest, Xs)
+    end
+end

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -16,4 +16,5 @@ module NullableArrays
     include("02_constructors.jl")
     include("03_primitives.jl")
     include("04_indexing.jl")
+    include("05_map.jl")
 end

--- a/test/05_map.jl
+++ b/test/05_map.jl
@@ -1,0 +1,44 @@
+module TestMap
+    using Base.Test
+    using NullableArrays
+
+    A = rand(10)
+    B = [1:10...]
+    X = NullableArray([1:10...])
+    Y = NullableArray(A)
+    Z = NullableArray(A, vcat(fill(true, 5), fill(false, 5)))
+    f{T}(x::Nullable{T}) = return Nullable(5*x.value, x.isnull)
+    f{T}(x::Nullable{T}, y::Number) = Nullable(x.value*y, x.isnull)
+    f{T}(x::Number, y::Nullable{T}) = f(y, x)
+    f(x::Nullable, y::Nullable) = Nullable(x.value*y.value,
+                                           x.isnull | y.isnull)
+    function f(x::Nullable, y::Nullable, z::Nullable)
+        Nullable(x.value*y.value*z.value, x.isnull | y.isnull | z.isnull)
+    end
+
+    @test isequal(map(f, X), NullableArray([ 5*i for i in 1:10 ]))
+    @test isequal(map(f, X, A),
+                  NullableArray([ X.values[i]*A[i] for i in 1:10 ])
+    )
+    @test isequal(map(f, X, Y),
+                  NullableArray([ X.values[i]*A[i] for i in 1:10])
+    )
+    @test isequal(map(f, X, Z),
+                  NullableArray([ X.values[i]*A[i] for i in 1:10],
+                                vcat(fill(true, 5), fill(false, 5))
+                  )
+    )
+    @test isequal(map(f, X, Y, Z),
+                  NullableArray([ X.values[i]*A[i]*A[i] for i in 1:10 ],
+                                vcat(fill(true, 5), fill(false, 5))
+                  )
+    )
+
+    @test isequal(map!(f, similar(X), X), NullableArray([ 5*i for i in 1:10 ]))
+    @test isequal(map!(f, NullableArray(Float64, 10), X, Y, Z),
+                  NullableArray([ X.values[i]*A[i]*A[i] for i in 1:10 ],
+                                vcat(fill(true, 5), fill(false, 5))
+                  )
+    )
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ my_tests = [
     "02_constructors.jl",
     "03_primitives.jl",
     "04_indexing.jl",
+    "05_map.jl"
 ]
 
 println("Running tests:")


### PR DESCRIPTION
This PR extends `Base.map!` support for `NullableArray` destination objects as well as `Base.map` support for 1, 2 and N `NullableArray` arguments. Much of this functionality is directly inheritable from Base, but the present implementations are optimized for a callable first argument much the same way as is `Base.broadcast!`, except they don't make use of the latter's caching mechanism. Thus there is a slight overhead for generating a new function for each call, but the overall performance seems good based on some informal tests. In any case, the present methods will be easy enough to pull out when `Function`s are overhauled down the line.

Note that if one calls `map` on arguments that are not all `NullableArray` objects (save for the first argument, i.e. the function to be mapped) such a call will fall back to the generic method defined in `base/abstractarray.jl`. This ought to work just fine -- it will just be slower for now.

Some tests for `map!`/`map` are also included in this PR.
