### PR TITLE
Add vector and matrix methods, appropriate tests

### DIFF
--- a/src/02_constructors.jl
+++ b/src/02_constructors.jl
@@ -1,5 +1,5 @@
 
-# ----- Outer Constructors ------------------------------------------------------------- #
+# ----- Outer Constructors -------------------------------------------------- #
 
 # ----- Constructor #1
 # The following provides an outer constructor whose argument signature matches
@@ -9,7 +9,7 @@ function NullableArray{T, N}(A::AbstractArray{T, N},
     return NullableArray{T, N}(A, m)
 end
 
-# ----- Constructor #2 ------------------------------------------------------------------#
+# ----- Constructor #2 -------------------------------------------------------#
 # Constructs a NullableArray from an Array 'a' of values and an optional
 # Array{Bool, N} mask. If omitted, the mask will default to an array of
 # 'false's the size of 'a'.
@@ -17,7 +17,7 @@ function NullableArray{T, N}(A::AbstractArray{T, N}) # -> NullableArray{T, N}
     return NullableArray{T, N}(A, fill(false, size(A)))
 end
 
-# ----- Constructor #3 ------------------------------------------------------------------#
+# ----- Constructor #3 -------------------------------------------------------#
 # TODO: Uncomment this doc entry when Base Julia can parse it correctly.
 # @doc """
 # Allow users to construct a quasi-uninitialized `NullableArray` object by
@@ -34,7 +34,7 @@ function NullableArray{T}(::Type{T}, dims::Dims) # -> NullableArray{T, N}
     return NullableArray(Array(T, dims), fill(true, dims))
 end
 
-# ----- Constructor #4 ------------------------------------------------------------------#
+# ----- Constructor #4 -------------------------------------------------------#
 # Constructs an empty NullableArray of type parameter T and number of dimensions
 # equal to the number of arguments given in 'dims...', where the latter are
 # dimension lengths.
@@ -42,7 +42,7 @@ function NullableArray(T::Type, dims::Int...) # -> NullableArray
     return NullableArray(T, dims)
 end
 
-# ----- Constructor #5 ------------------------------------------------------------------#
+# ----- Constructor #5 -------------------------------------------------------#
 # The following method constructs a NullableArray from an Array{Any} argument
 # 'A' that contains some placeholder of type 'T' for null values.
 #
@@ -74,4 +74,13 @@ function NullableArray{T, U}(A::AbstractArray,
         !isnull && setindex!(_values, A[i], i)
     end
     return NullableArray(_values, _isnull)
+end
+
+#----- Constructor #6 --------------------------------------------------------#
+
+# The following method allows for the construction of zero-element
+# NullableArrays by calling the parametrized type on zero arguments.
+# TODO: add support for dimensions arguments?
+function Base.call{T, N}(::Type{NullableArray{T, N}})
+    NullableArray(T, ntuple(i->0, N))
 end

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -10,11 +10,14 @@ module NullableArrays
            dropnull,
            anynull,
            allnull,
-           nullify!
+           head,
+           nullify!,
+           tail
 
     include("01_typedefs.jl")
     include("02_constructors.jl")
     include("03_primitives.jl")
     include("04_indexing.jl")
     include("05_map.jl")
+    include("nullablevector.jl")
 end

--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -1,0 +1,64 @@
+#----- head/tail -------------------------------------------------------------#
+
+head(X::NullableArray) = X[1:min(6, length(X))]
+tail(X::NullableArray) = X[max(1, length(X) - 5):length(X)]
+
+#----- Base.push! ------------------------------------------------------------#
+
+function Base.push!{T, V}(X::NullableVector{T}, v::V)
+    push!(X.values, v)
+    push!(X.isnull, false)
+end
+
+function Base.push!{T, V}(X::NullableVector{T}, v::Nullable{V})
+    if v.isnull
+        resize!(X.values, length(X.values) + 1)
+        push!(X.isnull, true)
+    else
+        push!(X.values, v.value)
+        push!(X.isnull, false)
+    end
+end
+
+#----- Base.pop! -------------------------------------------------------------#
+
+function Base.pop!{T}(X::NullableVector{T}) # -> T
+    val, isnull = pop!(X.values), pop!(X.isnull)
+    isnull ? Nullable{T}() : Nullable(val)
+end
+
+#----- Base.unshift! ---------------------------------------------------------#
+
+function Base.unshift!(X::NullableVector, v::Nullable) # -> NullableVector{T}
+    if v.isnull
+        ccall(:jl_array_grow_beg, Void, (Any, UInt), X.values, 1)
+        unshift!(X.isnull, true)
+    else
+        unshift!(X.values, v.value)
+        unshift!(X.isnull, false)
+    end
+    return X
+end
+
+function Base.unshift!(X::NullableVector, v) # -> NullableVector{T}
+    unshift!(X.values, v)
+    unshift!(X.isnull, false)
+    return X
+end
+
+function Base.unshift!(X::NullableVector, vs...)
+    return unshift!(unshift!(X, last(vs)), vs[1:endof(vs)-1]...)
+end
+
+#----- Base.shift! -----------------------------------------------------------#
+
+function Base.shift!{T}(X::NullableVector{T})
+    val, isnull = shift!(X.values), shift!(X.isnull)
+    if isnull
+        return Nullable{T}()
+    else
+        return Nullable{T}(val)
+    end
+end
+
+#----- Base.splice! ----------------------------------------------------------#

--- a/test/nullablematrix.jl
+++ b/test/nullablematrix.jl
@@ -1,0 +1,17 @@
+module TestMatrix
+    using NullableArrays
+    using Base.Test
+
+    #----- test Base.diag -----#
+    A = reshape([1:25...], 5, 5)
+    m = fill(false, 5, 5)
+    m[1] = true
+    m[25] = true
+    X = NullableArray(A)
+    Y = NullableArray(A, m)
+
+    @test isequal(diag(X), NullableArray([1, 7, 13, 19, 25]))
+    @test isequal(diag(Y), NullableArray([1, 7, 13, 19, 25],
+                                         [true, false, false, false, true]))
+
+end

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -1,0 +1,64 @@
+module TestNullableVector
+    using NullableArrays
+    using Base.Test
+
+    A = [1:10...]
+    B = [1:5...]
+
+    X = NullableArray(A)
+    Y = NullableArray(B)
+
+    #----- test head/tail -----#
+    @test isequal(head(X), NullableArray([1:6...]))
+    @test isequal(tail(X), NullableArray([5:10...]))
+
+    #----- test Base.push! -----#
+
+    Z = NullableVector{Int}()
+    push!(Z, 5)
+    @test isequal(Z[1], Nullable(5))
+
+    #----- test Base.pop! -----#
+
+    @test isequal(pop!(Z), Nullable(5))
+
+    #----- test Base.unshift! -----#
+
+    @test isequal(unshift!(X, 3), NullableArray(vcat(3, [1:10...])))
+    @test isequal(unshift!(X, Nullable(2)),
+                  NullableArray(vcat([2, 3], [1:10...])))
+    @test isequal(unshift!(X, Nullable{Int}()),
+                  NullableArray(vcat([1, 2, 3], [1:10...]),
+                                vcat(true, fill(false, 12))
+                  )
+          )
+    @test isequal(unshift!(Y, 1, Nullable(), Nullable(3)),
+                  NullableArray([1, 2, 3, 1, 2, 3, 4, 5],
+                                [false, true, false, false,
+                                false, false, false, false]
+                  )
+          )
+
+    #----- test Base.shift! -----#
+
+    Z = NullableArray([1:10...])
+    @test isequal(shift!(Z), Nullable(1))
+    @test isequal(Z, NullableArray([2:10...]))
+
+    #----- test Base.splice! -----#
+
+
+    #----- test Base.deleteat! -----#
+
+
+    #----- test Base.append! -----#
+
+
+    #----- test Base.sizehint! -----#
+
+
+    #----- test padnull! -----#
+
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,9 @@ my_tests = [
     "03_primitives.jl",
     "04_indexing.jl",
     "05_map.jl",
-    "broadcast.jl"
+    "broadcast.jl",
+    "nullablevector.jl",
+    "nullablematrix.jl"
 ]
 
 println("Running tests:")


### PR DESCRIPTION
This PR adds the following methods for `NullableVector`s:

-`head(X::NullableArray)`
-`tail(X::NullableArray)`
-`Base.push!{T, V}(X::NullableVector{T}, v::V)`
-`Base.push!{T, V}(X::NullableVector{T}, v::Nullable{V})`
-`Base.pop!{T}(X::NullableVector{T})`
-`Base.unshift!(X::NullableVector, v::Nullable)`
-`Base.unshift!(X::NullableVector, v)`
-`Base.unshift!(X::NullableVector, vs...)`
-`Base.shift!{T}(X::NullableVector{T})`

as well as tests for most of the above methods. Also adds a test for `diag(X::NullableMatrix)`, which is inherited from Base.

It also adds a outer constructor that allows one to construct 0-element `NullableArrays` by calling

``` julia
NullableArray{T, N}()
```
