### PR TITLE
Methods additions and revisions

### DIFF
--- a/src/03_primitives.jl
+++ b/src/03_primitives.jl
@@ -123,6 +123,20 @@ end
 
 anynull(X::NullableArray) = any(X.isnull) # -> Bool
 
+# NOTE: the following currently short-circuits.
+function anynull(A::AbstractArray) # -> Bool
+    for a in A
+        if isa(a, Nullable)
+            a.isnull && (return true)
+        end
+    end
+    return false
+end
+
+function anynull(xs::NTuple) # -> Bool
+    return anynull(collect(xs))
+end
+
 # ----- allnull --------------------------------------------------------------#
 
 allnull(X::NullableArray) = all(X.isnull) # -> Bool

--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -8,6 +8,7 @@ tail(X::NullableArray) = X[max(1, length(X) - 5):length(X)]
 function Base.push!{T, V}(X::NullableVector{T}, v::V)
     push!(X.values, v)
     push!(X.isnull, false)
+    return X
 end
 
 function Base.push!{T, V}(X::NullableVector{T}, v::Nullable{V})
@@ -18,6 +19,7 @@ function Base.push!{T, V}(X::NullableVector{T}, v::Nullable{V})
         push!(X.values, v.value)
         push!(X.isnull, false)
     end
+    return X
 end
 
 #----- Base.pop! -------------------------------------------------------------#


### PR DESCRIPTION
Additions to `03_primitives.jl`
-`anynull(A::AbstractArray)`
-`anynull(xs::NTuple)`

Additions to `04_indexing.jl`
-`Base.getindex{T, N}(X::NullableArray{T, N})`
-`Base.getindex{T, N}(I::Nullable{Int}...)`

Revisions to `04_indexing.jl`
-`unsafe_getindex_notnull(X::NullableArray, I::Int)` now returns a Nullable value
-`Base._checkbounds{T<:Real}(sz::Int, I::NullableArray{T})` now calls `Base._checkbounds` rather than `Base.checkbounds`and also returns a `Bool`. These modifications were required to make possible indexing into an arbitrary `AbstractArray` with a `NullableArray` index.

Revisions to `nullablevector.jl`
-both `Base.push!` methods now return the target `NullableVector`.
