### PR TITLE
Add `@^` macro, respective tests

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -6,6 +6,9 @@ module NullableArrays
            NullableVector,
            NullableMatrix,
 
+           # Macros
+           @^,
+
            # Methods
            dropnull,
            anynull,
@@ -22,4 +25,5 @@ module NullableArrays
     include("04_indexing.jl")
     include("05_map.jl")
     include("nullablevector.jl")
+    include("lift.jl")
 end

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -1,0 +1,58 @@
+
+#----- @^ --------------------------------------------------------------------#
+
+macro ^(call, T...)
+    arg_cache = Dict{Union{Symbol, Expr}, Expr}()
+    if !(isa(call, Expr)) || call.head != :call
+        throw(ArgumentError("@^: argument must be a function call"))
+    end
+
+    if length(T) == 0
+        e_type = :(Union{})
+    elseif length(T) == 1
+        e_type = T[1]
+    else
+        throw(ArgumentError("@^: wrong number of arguments"))
+    end
+
+    e_call = gen_calls(call, arg_cache)
+    args = collect(keys(arg_cache))
+    e_nullcheck = :($(args[1]).isnull)
+    for i = 2:length(args)
+        e_nullcheck = Expr(:||, e_nullcheck, :($(args[i]).isnull))
+    end
+
+    return esc(:(
+        if $e_nullcheck
+            Nullable{$e_type}()
+        else
+            Nullable($e_call)
+        end )
+    )
+end
+
+# base case for literals
+gen_calls(e, arg_cache) = e
+
+# base case for symbols
+function gen_calls(e::Symbol, arg_cache)
+    new_arg = get!(arg_cache, e, :($e.value))
+    return new_arg
+end
+
+# recursively modify expression tree
+function gen_calls(e::Expr, arg_cache)
+    if e.head == :call
+        return Expr(:call, e.args[1], gen_calls(e.args[2:end], arg_cache)...)
+    elseif e.head == :ref
+        new_arg = get!(arg_cache, e, :($e.value))
+        return new_arg
+    else
+        return e
+    end
+end
+
+# recursive case for `args` field arrays
+function gen_calls(args::Array, arg_cache)
+    return [ gen_calls(arg, arg_cache) for arg in args ]
+end

--- a/test/lift.jl
+++ b/test/lift.jl
@@ -1,0 +1,19 @@
+module TestLift
+    using NullableArrays
+    using Base.Test
+
+    f(x::Int) = 5 * x
+    g(x::Int, y::Int) = x + y
+    x = Nullable(5)
+    y = Nullable{Int}()
+    X = NullableArray([1, 2, 3, 4, 5])
+
+    @test isequal(@^(f(x), Int), Nullable(25))
+    @test isequal(@^(f(y), Int), Nullable{Int}())
+    @test isequal(@^(f(y)), Nullable{Union{}}())
+
+    @test isequal(@^(f(X[1]) + g(x, X[1]), Int), Nullable(11))
+    @test isequal(@^(f(X[1]) + g(y, X[1]), Int), Nullable{Int}())
+    @test isequal(@^(f(X[1]) + g(y, X[1])), Nullable{Union{}}())
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ my_tests = [
     "04_indexing.jl",
     "05_map.jl",
     "broadcast.jl",
+    "lift.jl",
     "nullablevector.jl",
     "nullablematrix.jl"
 ]


### PR DESCRIPTION
This PR introduces the lifting macro `@^`, which can be used to annotate function calls as so: `@^ f(x) Int`. The latter type argument designates what type of `Nullable{T}` ought to be returned in case one of the function call arguments is null. If the type argument is omitted, then `Nullable{Union{}}` will be returned in the case of a null argument.

``` julia
julia> macroexpand(:( @^ f(x, y) Int ))
:(if y.isnull || x.isnull # line 27:
        Nullable{Int}()
    else  # line 29:
        Nullable(f(x.value,y.value))
    end)

julia> macroexpand(:( @^ f(x, X[i]) + g(y, Y[i]) ))
:(if ((y.isnull || X[i].isnull) || x.isnull) || Y[i].isnull # line 27:
        Nullable{Union{}}()
    else  # line 29:
        Nullable(f(x.value,X[i].value) + g(y.value,Y[i].value))
    end)
```
