### PR TITLE
Various revisions

### DIFF
--- a/src/03_primitives.jl
+++ b/src/03_primitives.jl
@@ -108,17 +108,6 @@ end
 
 dropnull(X::NullableVector) = copy(X.values[!X.isnull]) # -> Vector{T}
 
-# ----- Base.isnull ----------------------------------------------------------#
-
-Base.isnull(X::NullableArray) = copy(X.isnull) # -> Array{Bool, N}
-
-Base.isnull(X::NullableArray, i::Integer) = X.isnull[i] # -> Bool
-
-# Ought we to implement non-varargs methods for I of length 1, 2, 3, 4?
-function Base.isnull(X::NullableArray, I::Any...) # -> Bool
-    getindex(X.isnull, I...)
-end
-
 # ----- anynull --------------------------------------------------------------#
 
 anynull(X::NullableArray) = any(X.isnull) # -> Bool

--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -192,5 +192,5 @@ function Base.reverse!(X::NullableVector, s=1, n=length(X))
 end
 
 function Base.reverse(X::NullableVector, s=1, n=length(X))
-    return reverse!(copy(X))
+    return reverse!(copy(X), s, n)
 end

--- a/test/03_primitives.jl
+++ b/test/03_primitives.jl
@@ -43,7 +43,7 @@ module TestPrimitives
     function nonbits(dv)
         ret = similar(dv, Integer)
         for i = 1:length(dv)
-            if !isnull(dv, i)
+            if !dv.isnull[i]
                 ret[i] = dv[i]
             end
         end
@@ -151,21 +151,11 @@ module TestPrimitives
     z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
     @test dropnull(z) == [1, 2, 3, 5, 7]
 
-# ----- test Base.isnull -----------------------------------------------------#
-
-    @test isnull(z) == [false, false, false, true, false, true, false, true]
-    @test isnull(z, 1) == false
-    @test isnull(z, 4) == true
-    z = NullableArray([1 nothing; nothing 4], Int, Void)
-    @test isnull(z, 1, 1) == false
-    @test isnull(z, 1, 2) == true
-    z = NullableArray(fill(Int, 3, 3, 3))
-    @test isnull(z, 1, 3, 2) == false
-
 # ----- test anynull ---------------------------------------------------------#
 
     # anynull(X::NullableArray)
-    @test anynull(z) == false
+    @test anynull(z) == true
+    @test anynull(dropnull(z)) == false
     z = NullableArray(Int, 10)
     @test anynull(z) == true
 


### PR DESCRIPTION
-Remove `Base.isnull` methods, revise tests accordingly. This satisfies the calls of the masses in https://github.com/johnmyleswhite/NullableArrays.jl/issues/22

-Fix an error in `Base.reverse` where keyword arguments were not passed to mutating method called in function body.
