### PR TITLE
Revise lift macro `@^`, respective tests

### DIFF
--- a/src/lift.jl
+++ b/src/lift.jl
@@ -7,9 +7,7 @@ macro ^(call, T...)
         throw(ArgumentError("@^: argument must be a function call"))
     end
 
-    if length(T) == 0
-        e_type = :(Union{})
-    elseif length(T) == 1
+    if length(T) == 1
         e_type = T[1]
     else
         throw(ArgumentError("@^: wrong number of arguments"))

--- a/test/lift.jl
+++ b/test/lift.jl
@@ -10,10 +10,10 @@ module TestLift
 
     @test isequal(@^(f(x), Int), Nullable(25))
     @test isequal(@^(f(y), Int), Nullable{Int}())
-    @test isequal(@^(f(y)), Nullable{Union{}}())
+    @test_throws ArgumentError eval(macroexpand(:( @^f(y) )))
+    @test_throws ArgumentError eval(macroexpand(:( @^ if x > 0; f(x) end )))
 
     @test isequal(@^(f(X[1]) + g(x, X[1]), Int), Nullable(11))
     @test isequal(@^(f(X[1]) + g(y, X[1]), Int), Nullable{Int}())
-    @test isequal(@^(f(X[1]) + g(y, X[1])), Nullable{Union{}}())
 
 end


### PR DESCRIPTION
This PR introduces the following revision to the lift macro `@^`:

-Require type argument when calling `@^`, remove default behavior to return `Nullable{Union{}}` when type argument is omitted.

This revision is in response to suggestions made in https://github.com/johnmyleswhite/NullableArrays.jl/pull/21.
