### PR TITLE
Experiment with presentation of `Nullable`s

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -25,5 +25,6 @@ module NullableArrays
     include("04_indexing.jl")
     include("05_map.jl")
     include("nullablevector.jl")
+    include("io.jl")
     include("lift.jl")
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,6 @@
+# Experiments with different means of printing present and missing Nullable
+# values to the screen
+
+function Base.show{T}(io::IO, x::Nullable{T})
+    print(io, ifelse(x.isnull, "?{$T}", "$(x.value)?"))
+end


### PR DESCRIPTION
This PR introduces an experimental means of displaying both empty and present `Nullable` values. The goal is to find some means of presenting such values so that the world `Nullable` does not clutter the screen when printing and showing `NullableArray`s. The scheme introduced here is that a present `Nullable{T}` value is shown as the interpolated value field followed by a question mark:

``` julia
julia> show(Nullable(5))
5?
```

and a missing `Nullable{T}` value is shown as `?{T}`:

``` julia
julia> show(Nullable{Int}())
?{Int64}
```

I know this breaks with the C# notation and such, but I don't like using the same pattern to represent present and null values, in part because of the ambiguity when one wants to show `Nullable(Int)`, although I suppose the meaning can be inferred easily enough from context. I'm not wedded to the current design by any means. But I do want to start somewhere.
