### PR TITLE
Operators

### DIFF
--- a/perf/broadcast.jl
+++ b/perf/broadcast.jl
@@ -1,0 +1,186 @@
+using DataArrays
+using NullableArrays
+
+srand(1)
+M1 = rand(Bool, 5_000_000)
+M2 = rand(Bool, 5_000_000, 2)
+A1 = rand(5_000_000)
+A2 = rand(Float64, 5_000_000, 2)
+B1 = rand(Bool, 5_000_000)
+B2 = rand(Bool, 5_000_000, 2)
+C1 = rand(1:10, 5_000_000)
+C2 = rand(Int, 5_000_000, 2)
+L = Array(Float64, 5_000_000, 2)
+
+U = NullableArray(Float64, 5_000_000, 2)
+X1 = NullableArray(A1)
+X2 = NullableArray(A2)
+Y1 = NullableArray(A1, M1)
+Y2 = NullableArray(A2, M2)
+Z1 = NullableArray(B1)
+Z2 = NullableArray(B2)
+Q1 = NullableArray(C1)
+Q2 = NullableArray(C2)
+V1 = NullableArray(C1, M1)
+V2 = NullableArray(C2, M2)
+
+D = DataArray(Float64, 5_000_000, 2)
+E1 = DataArray(A1)
+E2 = DataArray(A2)
+F1 = DataArray(A1, M1)
+F2 = DataArray(A2, M2)
+G1 = DataArray(B1)
+G2 = DataArray(B2)
+H1 = DataArray(C1)
+H2 = DataArray(C2)
+I1 = DataArray(C1, M1)
+I2 = DataArray(C2, M2)
+
+f(x, y) = x * y
+
+function test_broadcast()
+
+    println("Method: broadcast!(f, dest, A1, A2) (no empty entries):")
+    broadcast!(f, L, A1, A2)
+    print("  For Array{Float64}:          ")
+    @time(broadcast!(f, L, A1, A2))
+
+    broadcast!(f, U, X1, X2)
+    print("  For NullableArray{Float64}:  ")
+    @time(broadcast!(f, U, X1, X2))
+
+    broadcast!(f, D, E1, E2)
+    print("  For DataArray{Float64}:      ")
+    @time(broadcast!(f, D, E1, E2))
+
+    println()
+    println("Method: broadcast!(f, dest, A1, A2) (~half empty entries):")
+    broadcast!(f, U, Y1, Y2)
+    print("  For NullableArray{Float64}:  ")
+    @time(broadcast!(f, U, Y1, Y2))
+
+    print("  For DataArray{Float64}:      ")
+    broadcast!(f, D, F1, F2)
+    @time(broadcast!(f, D, F1, F2))
+    nothing
+end
+
+function test_ops1()
+    for op in (
+        :(.+),
+        :(.-),
+        :(.*),
+        :(./),
+        :(.%),
+        :(.^),
+    )
+        _op = symbol("$op")
+        println("Method: $_op (no empty entries)")
+        @eval begin
+            $_op(A1, A2)
+            $_op(X1, X2)
+            $_op(E1, E2)
+            print("  For Array{Float64}:          ")
+            @time($_op(A1, A2))
+            print("  For NullableArray{Float64}:  ")
+            @time($_op(X1, X2))
+            print("  For DataArray{Float64}:      ")
+            @time($_op(E1, E2))
+        end
+    end
+
+    println("Method: .>> (no empty entries)")
+    .>>(C2, C1)
+    .>>(V2, V1)
+    .>>(H2, H1)
+    print("  For Array{Float64}:          ")
+    @time(.>>(C2, C1))
+    print("  For NullableArray{Float64}:  ")
+    @time(.>>(Q2, Q1))
+    print("  For DataArray{Float64}:      ")
+    @time(.>>(H2, H1))
+
+    for op in (
+        :(.==),
+        :(.!=),
+        :(.<),
+        :(.>),
+        :(.<=),
+        :(.>=),
+    )
+        _op = symbol("$op")
+        println("Method: $_op (no empty entries)")
+        @eval begin
+            $_op(A1, A2)
+            $_op(X1, X2)
+            $_op(E1, E2)
+            print("  For Array{Float64}:          ")
+            @time($_op(A1, A2))
+            print("  For NullableArray{Float64}:  ")
+            @time($_op(X1, X2))
+            print("  For DataArray{Float64}:      ")
+            @time($_op(E1, E2))
+        end
+    end
+    nothing
+end
+
+function test_ops2()
+    for op in (
+        :(.+),
+        :(.-),
+        :(.*),
+        :(./),
+        :(.%),
+        :(.^),
+    )
+        _op = symbol("$op")
+        println("Method: $_op (~half empty entries)")
+        @eval begin
+            $_op(A1, A2)
+            $_op(Y1, Y2)
+            $_op(F1, F2)
+            print("  For Array{Float64}:          ")
+            @time($_op(A1, A2))
+            print("  For NullableArray{Float64}:  ")
+            @time($_op(Y1, Y2))
+            print("  For DataArray{Float64}:      ")
+            @time($_op(F1, F2))
+        end
+    end
+
+    println("Method: .>> (~half empty entries)")
+    .>>(C2, C1)
+    .>>(V2, V1)
+    # .>>(I2, I1)
+    print("  For Array{Float64}:          ")
+    @time(.>>(C2, C1))
+    print("  For NullableArray{Float64}:  ")
+    @time(.>>(V2, V1))
+    # print("For DataArray{Float64}:      ")
+    # @time(.>>(I2, I1))
+
+    for op in (
+        :(.==),
+        :(.!=),
+        :(.<),
+        :(.>),
+        :(.<=),
+        :(.>=),
+    )
+        _op = symbol("$op")
+        println("Method: $_op (~half empty entries)")
+        @eval begin
+            $_op(A1, A2)
+            $_op(Y1, Y2)
+            $_op(F1, F2)
+            print("  For Array{Float64}:          ")
+            @time($_op(A1, A2))
+            print("  For NullableArray{Float64}:  ")
+            @time($_op(Y1, Y2))
+            print("  For DataArray{Float64}:      ")
+            @time($_op(F1, F2))
+        end
+    end
+    nothing
+end

--- a/perf/lift.jl
+++ b/perf/lift.jl
@@ -1,0 +1,32 @@
+using NullableArrays
+
+srand(1)
+N = 5_000_000
+f(x, y) = x * y
+g(x, y) = x + y
+
+X = NullableArray(rand(N))
+Y = NullableArray(rand(N))
+
+Xn = NullableArray(rand(N), rand(Bool, N))
+Yn = NullableArray(rand(N), rand(Bool, N))
+
+function tracedot(X, Y)
+    res = Nullable(0.0)
+    for i in 1:length(X)
+         res += @^ f(X[i], Y[i]) Float64
+    end
+    return res
+end
+
+function test_no_nulls()
+    tracedot(X, Y)
+    # tracedot(X, Y)
+    @time(tracedot(X, Y))
+end
+
+function test_half_nulls()
+    tracedot(Xn, Yn)
+    # tracedot(Xn, Yn)
+    @time(tracedot(Xn, Yn))
+end

--- a/perf/map.jl
+++ b/perf/map.jl
@@ -1,0 +1,19 @@
+using NullableArrays
+
+srand(1)
+A = rand(5_000_000)
+B = rand(Bool, 5_000_000)
+
+X = NullableArray(Float64, 5_000_000)
+Y = NullableArray(A)
+Z = NullableArray(A, B)
+
+f{T}(x::Nullable{T}) = return Nullable(5*x.value, x.isnull)
+
+function test_map()
+    map!(f, X, Y)
+    map!(f, X, Z)
+    # map!(f, X, Y)
+    @time(map!(f, X, Y))
+    @time(map!(f, X, Z))
+end

--- a/perf/mapreduce.jl
+++ b/perf/mapreduce.jl
@@ -1,6 +1,7 @@
 using NullableArrays
 using DataArrays
 
+srand(1)
 A = rand(5_000_000)
 B = rand(Bool, 5_000_000)
 mu_A = mean(A)
@@ -14,7 +15,7 @@ f{T<:Number}(x::Nullable{T}) = Nullable(5 * x.value, x.isnull)
 
 #-----------------------------------------------------------------------------#
 
-function test_mapreduce(A::AbstractArray, X::NullableArray)
+function test_mapreduce(A, X, D)
     mapreduce(f, Base.(:+), A)
     mapreduce(f, Base.(:+), X)
     mapreduce(f, Base.(:+), D)
@@ -27,7 +28,7 @@ function test_mapreduce(A::AbstractArray, X::NullableArray)
     @time(mapreduce(f, Base.(:+), D))
 end
 
-function test_reduce(A::AbstractArray, X::NullableArray)
+function test_reduce(A, X, D)
     reduce(Base.(:+), A)
     reduce(Base.(:+), X)
     reduce(Base.(:+), D)
@@ -40,7 +41,7 @@ function test_reduce(A::AbstractArray, X::NullableArray)
     @time(reduce(Base.(:+), D))
 end
 
-function test_sum1(A::AbstractArray, X::NullableArray)
+function test_sum1(A, X, D)
     sum(A)
     sum(X)
     sum(D)
@@ -53,7 +54,7 @@ function test_sum1(A::AbstractArray, X::NullableArray)
     @time(sum(D))
 end
 
-function test_sum2(A::AbstractArray, X::NullableArray)
+function test_sum2(A, X, D)
     sum(f, A)
     sum(f, X)
     sum(f, D)
@@ -66,7 +67,7 @@ function test_sum2(A::AbstractArray, X::NullableArray)
     @time(sum(f, D))
 end
 
-function test_prod1(A::AbstractArray, X::NullableArray)
+function test_prod1(A, X, D)
     prod(A)
     prod(X)
     prod(D)
@@ -79,7 +80,7 @@ function test_prod1(A::AbstractArray, X::NullableArray)
     @time(prod(D))
 end
 
-function test_prod2(A::AbstractArray, X::NullableArray)
+function test_prod2(A, X, D)
     prod(f, A)
     prod(f, X)
     prod(f, D)
@@ -92,7 +93,7 @@ function test_prod2(A::AbstractArray, X::NullableArray)
     @time(prod(f, D))
 end
 
-function test_minimum1(A::AbstractArray, X::NullableArray)
+function test_minimum1(A, X, D)
     minimum(A)
     minimum(X)
     minimum(D)
@@ -105,7 +106,7 @@ function test_minimum1(A::AbstractArray, X::NullableArray)
     @time(minimum(D))
 end
 
-function test_minimum2(A::AbstractArray, X::NullableArray)
+function test_minimum2(A, X, D)
     minimum(f, A)
     minimum(f, X)
     minimum(f, D)
@@ -118,7 +119,7 @@ function test_minimum2(A::AbstractArray, X::NullableArray)
     @time(minimum(f, D))
 end
 
-function test_maximum1(A::AbstractArray, X::NullableArray)
+function test_maximum1(A, X, D)
     maximum(A)
     maximum(X)
     maximum(D)
@@ -131,7 +132,7 @@ function test_maximum1(A::AbstractArray, X::NullableArray)
     @time(maximum(D))
 end
 
-function test_maximum2(A::AbstractArray, X::NullableArray)
+function test_maximum2(A, X, D)
     maximum(f, A)
     maximum(f, X)
     maximum(f, D)
@@ -144,7 +145,7 @@ function test_maximum2(A::AbstractArray, X::NullableArray)
     @time(maximum(f, D))
 end
 
-function test_sumabs(A::AbstractArray, X::NullableArray)
+function test_sumabs(A, X, D)
     sumabs(A)
     sumabs(X)
     sumabs(D)
@@ -157,7 +158,7 @@ function test_sumabs(A::AbstractArray, X::NullableArray)
     @time(sumabs(D))
 end
 
-function test_sumabs2(A::AbstractArray, X::NullableArray)
+function test_sumabs2(A, X, D)
     sumabs2(A)
     sumabs2(X)
     sumabs2(D)
@@ -241,18 +242,18 @@ function test_std(A::AbstractArray, X::NullableArray)
 end
 
 function testall()
-    test_mapreduce(A, X)
-    test_reduce(A, X)
-    test_sum1(A, X)
-    test_sum2(A, X)
-    test_prod1(A, X)
-    test_prod2(A, X)
-    test_minimum1(A, X)
-    test_minimum2(A, X)
-    test_maximum1(A, X)
-    test_maximum2(A, X)
-    test_sumabs(A, X)
-    test_sumabs2(A, X)
+    test_mapreduce(A, X, D)
+    test_reduce(A, X, D)
+    test_sum1(A, X, D)
+    test_sum2(A, X, D)
+    test_prod1(A, X, D)
+    test_prod2(A, X, D)
+    test_minimum1(A, X, D)
+    test_minimum2(A, X, D)
+    test_maximum1(A, X, D)
+    test_maximum2(A, X, D)
+    test_sumabs(A, X, D)
+    test_sumabs2(A, X, D)
     # test_mean1(A, X)
     # test_varm1(A, X)
     # test_varm2(X)
@@ -264,18 +265,6 @@ function testall()
 end
 
 testall()
-#
-# function sumabs1(X)
-#     res = Nullable(0.0)
-#     for i in 1:length(X)
-#         res += abs(X[i])
-#     end
-#     return res
-# end
-#
-# sumabs1(X)
-# @time(sumabs1(X))
-
 
 # # NullableArray vs. DataArray comparison
 # println("NullableArray vs. DataArray comparison")

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -27,5 +27,6 @@ module NullableArrays
     include("nullablevector.jl")
     include("lift.jl")
     include("operators.jl")
+    include("broadcast.jl")
     include("mapreduce.jl")
 end

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -25,7 +25,6 @@ module NullableArrays
     include("indexing.jl")
     include("map.jl")
     include("nullablevector.jl")
-    include("io.jl")
     include("lift.jl")
     include("operators.jl")
     include("mapreduce.jl")

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,0 +1,19 @@
+#----- broadcasted binary operations -----------------------------------------#
+
+# The following require specialized implementations because the base/broadcast
+# methods return BitArrays instead of similars of the arguments.
+# An alternative to the following implementations is simply to let the base
+# implementations use convert(::Type{Bool}, ::Nullable{Bool}), but this is
+# slower.
+for (op, scalar_op) in (
+    (:.==, :(==)),
+    (:.!=, :!=),
+    (:.<, :<),
+    (:.>, :>),
+    (:.<=, :<=),
+    (:.>=, :>=)
+)
+    @eval begin
+        ($op)(X::NullableArray, Y::NullableArray) = broadcast($scalar_op, X, Y)
+    end
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,6 +1,0 @@
-# Experiments with different means of printing present and missing Nullable
-# values to the screen
-
-function Base.show{T}(io::IO, x::Nullable{T})
-    print(io, ifelse(x.isnull, "?{$T}", "$(x.value)?"))
-end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -110,16 +110,6 @@ for (fn, f, op) in ((:(Base.sumabs), Base.AbsFun(), Base.AddFun()),
         mapreduce($f, $op, X; skipnull=skipnull)
 end
 
-#----- Base.sumabs -----------------------------------------------------------#
-
-# function Base.sumabs{T}(X::NullableArray{T}; skipnull::Bool = false)
-#     anynull(X) && return Nullable{T}()
-#     return Nullable(sumabs(X.values))
-# end
-
-#----- Base.sumabs2 ----------------------------------------------------------#
-
-
 #----- Base.minimum / Base.maximum -------------------------------------------#
 
 # internal methods


### PR DESCRIPTION
This PR primarily includes additions and revisions to performance profiling resources for `map`, `@^` and `broadcast` methods. During the course of profiling it was found that certain element-wise operators required specialized `NullableArray` implementations. The latter are added in the new file `src/broadcast.jl`.

This PR also removes the `Base.show` overwrite (i.e. the former `src/io.jl` experiment).
