### PR TITLE
Tests

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -93,3 +93,29 @@ function Base.abs2{T}(x::Nullable{T})
         error()
     end
 end
+
+function Base.sqrt{T}(x::Nullable{T})
+    if isbits(T)
+        return Nullable(sqrt(x.value), x.isnull)
+    else
+        error()
+    end
+end
+
+## Lifted functors
+
+function Base.call{S1, S2}(::Base.MinFun, x::Nullable{S1}, y::Nullable{S2})
+    if isbits(S1) & isbits(S2)
+        return Nullable(Base.scalarmin(x.value, y.value), x.isnull | y.isnull)
+    else
+        error()
+    end
+end
+
+function Base.call{S1, S2}(::Base.MaxFun, x::Nullable{S1}, y::Nullable{S2})
+    if isbits(S1) & isbits(S2)
+        return Nullable(Base.scalarmax(x.value, y.value), x.isnull | y.isnull)
+    else
+        error()
+    end
+end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -24,7 +24,7 @@ module TestBroadcast
     f(x, y) = x * y
     f(x, y, z) = x * y * z
 
-    #----- test broadcast! -----#
+    # test broadcast!
     @test isequal(broadcast!(f, Y, A, B),
                   NullableArray(broadcast(f, A, B)))
     @test isequal(broadcast!(f, Y, U, V),
@@ -34,7 +34,7 @@ module TestBroadcast
     @test isequal(broadcast!(f, Z, U, V),
                   NullableArray(broadcast!(f, Array(Int, 10, 2, 2), A, B), n))
 
-    #----- test broadcast -----#
+    # test broadcast
     @test isequal(broadcast(f, U, B),
                   NullableArray(broadcast(f, A, B)))
     @test isequal(broadcast(f, U, V),
@@ -42,7 +42,33 @@ module TestBroadcast
     @test isequal(broadcast(f, U, V, C),
                   NullableArray(broadcast(f, A, B, C), n))
 
-    #----- test broadcasted operators -----#
+    # test broadcasted arithmetic operators
+    A = rand(10)
+    X1 = NullableArray(A)
+    n = rand(2:5)
+    dims = rand(2:5, n)
+    B = rand(Float64, 10, dims...)
+    X2 = NullableArray(B)
+    M = rand(Bool, 10, dims...)
+    Y = NullableArray(B, M)
+
+    for op in (
+        (.+),
+        (.-),
+        (.*),
+        (./),
+        (.%),
+        (.^),
+        (.==),
+        (.!=),
+        (.<),
+        (.>),
+        (.<=),
+        (.>=),
+    )
+        @test isequal(op(X1, X2), NullableArray(op(A, B)))
+        @test isequal(op(X1, Y), NullableArray(op(A, B), M))
+    end
 
 
 end # module

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -1,0 +1,48 @@
+module TestReduce
+    using NullableArrays
+    using Base.Test
+
+    srand(1)
+    A = rand(10)
+    M = rand(Bool, 10)
+    M[rand(1:5)] = true
+    M[rand(6:10)] = false
+    X = NullableArray(A)
+    Y = NullableArray(A, M)
+    B = A[find(x->!x, M)]
+    f(x) = 5 * x
+    f{T<:Number}(x::Nullable{T}) = Nullable(5 * x.value, x.isnull)
+
+    @test isequal(mapreduce(f, +, X), Nullable(mapreduce(f, +, X.values)))
+    @test isequal(mapreduce(f, +, Y), Nullable{Float64}())
+    @test isequal(mapreduce(f, +, Y, skipnull=true),
+                  Nullable(mapreduce(f, +, B)))
+
+    @test isequal(reduce(+, X), Nullable(reduce(+, X.values)))
+    @test isequal(reduce(+, Y), Nullable{Float64}())
+    @test isequal(reduce(+, Y, skipnull=true),
+                Nullable(reduce(+, B)))
+
+    for method in (
+        sum,
+        prod,
+        minimum,
+        maximum,
+    )
+        @test isequal(method(X), Nullable(method(A)))
+        @test isequal(method(f, X), Nullable(method(f, A)))
+        @test isequal(method(Y), Nullable{Float64}())
+        @test isequal(method(Y, skipnull=true), Nullable(method(B)))
+        @test isequal(method(f, Y), Nullable{Float64}())
+        @test isequal(method(f, Y, skipnull=true), Nullable(method(f, B)))
+    end
+
+    for method in (
+        sumabs,
+        sumabs2,
+    )
+        @test isequal(method(X), Nullable(method(A)))
+        @test isequal(method(Y), Nullable{Float64}())
+        @test isequal(method(Y, skipnull=true), Nullable(method(B)))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,9 @@ my_tests = [
     "map.jl",
     "broadcast.jl",
     "nullablevector.jl",
-    "nullablematrix.jl"
+    "nullablematrix.jl",
+    "mapreduce.jl",
+    "statistics.jl"
 ]
 
 println("Running tests:")

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -1,0 +1,170 @@
+module TestStatistics
+    using NullableArrays
+    using StatsBase
+    using Base.Test
+
+    srand(1)
+    A = rand(10)
+    M = rand(Bool, 10)
+    mu_A = mean(A)
+    nmu_A = Nullable(mu_A)
+    i = rand(1:10)
+    M[rand(1:5)] = true
+    j = rand(1:10)
+    while j == i
+        j = rand(1:10)
+    end
+    M[j] = false
+    X = NullableArray(A)
+    Y = NullableArray(A, M)
+    B = A[find(x->!x, M)]
+    mu_B = mean(B)
+    nmu_B = Nullable(mu_B)
+
+    C = rand(10)
+    V = WeightVec(C)
+    R = rand(Bool, 10)
+    R[rand(1:10)] = true
+    R[j] = false
+    # W = WeightVec(NullableArray(C, R))
+
+    J = find(i -> (!M[i] & !R[i]), [1:10...])
+
+    # Test mean methods
+    @test isequal(mean(X), Nullable(mean(A)))
+    @test isequal(mean(Y), Nullable{Float64}())
+    @test isequal(mean(Y, skipnull=true), Nullable(mean(B)))
+    @test isequal(mean(X, V), Nullable(mean(A, V)))
+    # Following tests need to wait until WeightVec constructor is implemented
+    # for NullableArray argument
+    # @test isequal(mean(X, W), Nullable{Float64}())
+    # @test isequal(mean(X, W, skipnull=true), Nullable(mean(A[J], WeightVec(C[J]))))
+
+    # Test varm methods
+    @test isequal(varm(X, mu_A), Nullable(varm(A, mu_A)))
+    @test isequal(varm(X, mu_A, corrected=false),
+                  Nullable(varm(A, mu_A, corrected=false)))
+    @test isequal(varm(Y, mu_B), Nullable{Float64}())
+    @test isequal(varm(Y, mu_B, corrected=false), Nullable{Float64}())
+    @test isequal(varm(Y, mu_B, skipnull=true),
+                  Nullable(varm(B, mu_B)))
+    @test isequal(varm(Y, mu_B, corrected=false, skipnull=true),
+                  Nullable(varm(B, mu_B, corrected=false)))
+
+    @test isequal(varm(X, nmu_A), Nullable(varm(A, mu_A)))
+    @test isequal(varm(X, nmu_A, corrected=false),
+                  Nullable(varm(A, mu_A, corrected=false)))
+    @test isequal(varm(Y, nmu_B), Nullable{Float64}())
+    @test isequal(varm(Y, nmu_B, corrected=false), Nullable{Float64}())
+    @test isequal(varm(Y, nmu_B, skipnull=true),
+                  Nullable(varm(B, mu_B)))
+    @test isequal(varm(Y, nmu_B, corrected=false, skipnull=true),
+                  Nullable(varm(B, mu_B, corrected=false)))
+
+    @test_throws NullException varm(Y, Nullable{Float64}())
+
+    # Test Base.varzm
+    D1 = rand(5)
+    D2 = -1 .* D1
+    D = [D1; D2]
+    @test mean(D) == 0
+    Q = NullableArray(D)
+    S = rand(Bool, 5)
+    U = NullableArray(D, [S; S])
+    E = [D[find(x->!x, S)]; D[find(x->!x, S)]]
+
+    @test isequal(Base.varzm(Q), Nullable(Base.varzm(D)))
+    @test isequal(Base.varzm(Q, corrected=false),
+                  Nullable(Base.varzm(D, corrected=false)))
+    @test isequal(Base.varzm(U), Nullable{Float64}())
+    @test isequal(Base.varzm(U, corrected=false), Nullable{Float64}())
+    @test isequal(Base.varzm(U, skipnull=true),
+                  Nullable(Base.varzm(E)))
+    @test isequal(Base.varzm(U, corrected=false, skipnull=true),
+                  Nullable(Base.varzm(E, corrected=false)))
+
+    # Test var
+    @test isequal(var(X), Nullable(var(A)))
+    @test isequal(var(X, corrected=false), Nullable(var(A, corrected=false)))
+    @test isequal(var(X, mean=mu_A), Nullable(var(A, mean=mu_A)))
+    @test isequal(var(X, mean=nmu_A), Nullable(var(A, mean=mu_A)))
+    @test isequal(var(X, mean=mu_A, corrected=false),
+                  Nullable(var(A, mean=mu_A, corrected=false)))
+    @test isequal(var(X, mean=nmu_A, corrected=false),
+                  Nullable(var(A, mean=mu_A, corrected=false)))
+
+    @test isequal(var(Y), Nullable{Float64}())
+    @test isequal(var(Y, corrected=false), Nullable{Float64}())
+    @test isequal(var(Y, mean=mu_B), Nullable{Float64}())
+    @test isequal(var(Y, mean=nmu_B), Nullable{Float64}())
+    @test isequal(var(Y, mean=mu_B, corrected=false),
+                  Nullable{Float64}())
+    @test isequal(var(Y, mean=nmu_B, corrected=false),
+                  Nullable{Float64}())
+
+    @test isequal(var(Y, skipnull=true),
+                  Nullable(var(B)))
+    @test isequal(var(Y, corrected=false, skipnull=true),
+                  Nullable(var(B, corrected=false)))
+    @test isequal(var(Y, mean=mu_B, skipnull=true),
+                  Nullable(var(B, mean=mu_B)))
+    @test isequal(var(Y, mean=nmu_B, skipnull=true),
+                  Nullable(var(B, mean=mu_B)))
+    @test isequal(var(Y, mean=mu_B, corrected=false, skipnull=true),
+                  Nullable(var(B, mean=mu_B, corrected=false)))
+    @test isequal(var(Y, mean=nmu_B, corrected=false, skipnull=true),
+                  Nullable(var(B, mean=mu_B, corrected=false)))
+
+    # Test stdm
+    @test isequal(stdm(X, mu_A), Nullable(stdm(A, mu_A)))
+    @test isequal(stdm(X, mu_A, corrected=false),
+                  Nullable(stdm(A, mu_A, corrected=false)))
+    @test isequal(stdm(Y, mu_B), Nullable{Float64}())
+    @test isequal(stdm(Y, mu_B, corrected=false), Nullable{Float64}())
+    @test isequal(stdm(Y, mu_B, skipnull=true),
+                  Nullable(stdm(B, mu_B)))
+    @test isequal(stdm(Y, mu_B, corrected=false, skipnull=true),
+                  Nullable(stdm(B, mu_B, corrected=false)))
+
+    @test isequal(stdm(X, nmu_A), Nullable(stdm(A, mu_A)))
+    @test isequal(stdm(X, nmu_A, corrected=false),
+                  Nullable(stdm(A, mu_A, corrected=false)))
+    @test isequal(stdm(Y, nmu_B), Nullable{Float64}())
+    @test isequal(stdm(Y, nmu_B, corrected=false), Nullable{Float64}())
+    @test isequal(stdm(Y, nmu_B, skipnull=true),
+                  Nullable(stdm(B, mu_B)))
+    @test isequal(stdm(Y, nmu_B, corrected=false, skipnull=true),
+                  Nullable(stdm(B, mu_B, corrected=false)))
+
+    # Test std
+    @test isequal(std(X), Nullable(std(A)))
+    @test isequal(std(X, corrected=false), Nullable(std(A, corrected=false)))
+    @test isequal(std(X, mean=mu_A), Nullable(std(A, mean=mu_A)))
+    @test isequal(std(X, mean=nmu_A), Nullable(std(A, mean=mu_A)))
+    @test isequal(std(X, mean=mu_A, corrected=false),
+                  Nullable(std(A, mean=mu_A, corrected=false)))
+    @test isequal(std(X, mean=nmu_A, corrected=false),
+                  Nullable(std(A, mean=mu_A, corrected=false)))
+
+    @test isequal(std(Y), Nullable{Float64}())
+    @test isequal(std(Y, corrected=false), Nullable{Float64}())
+    @test isequal(std(Y, mean=mu_B), Nullable{Float64}())
+    @test isequal(std(Y, mean=nmu_B), Nullable{Float64}())
+    @test isequal(std(Y, mean=mu_B, corrected=false),
+                  Nullable{Float64}())
+    @test isequal(std(Y, mean=nmu_B, corrected=false),
+                  Nullable{Float64}())
+
+    @test isequal(std(Y, skipnull=true),
+                  Nullable(std(B)))
+    @test isequal(std(Y, corrected=false, skipnull=true),
+                  Nullable(std(B, corrected=false)))
+    @test isequal(std(Y, mean=mu_B, skipnull=true),
+                  Nullable(std(B, mean=mu_B)))
+    @test isequal(std(Y, mean=nmu_B, skipnull=true),
+                  Nullable(std(B, mean=mu_B)))
+    @test isequal(std(Y, mean=mu_B, corrected=false, skipnull=true),
+                  Nullable(std(B, mean=mu_B, corrected=false)))
+    @test isequal(std(Y, mean=nmu_B, corrected=false, skipnull=true),
+                  Nullable(std(B, mean=mu_B, corrected=false)))
+end


### PR DESCRIPTION
This PR primarily adds tests for broadcasted operators and `mapreduce`-related functionality including statistic-related methods.

It also includes various bug fixes that were uncovered during the writing/running of the aforementioned tests. These bugs were mostly minor, due either to typos or missing lifted methods. A recurring theme in developing the `mapreduce` functionality is having to deal with `if` statements in already-existing `Base` methods. These methods might otherwise be applicable to `Nullable` arguments, except that comparisons of such arguments return `Nullable{Bool}` objects which incur errors in said `if` statements. This usually means that a method _somewhere_ has to be rewritten to accept `Nullable` arguments -- though it just now occurs to me that defining an `ifelse(x::Nullable{Bool}, x, z)` method might go a long way in treating these situations (but it also might make the ones it doesn't treat properly even more confusing to debug). That would actually be a great example of multiple dispatch in the service of facilitating extension. (I'll include these thoughts in https://github.com/johnmyleswhite/NullableArrays.jl/issues/20).
