### PR TITLE
Fix error in `minimum`, `maximum`

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -41,7 +41,7 @@ function Base.varm{T}(X::NullableArray{T}, m::Number; corrected::Bool=true,
                     abs2(X.values[Base.findnextnot(X.isnull, 1)] - m)/(1 - Int(corrected))
             )
         )
-        /(nnull == 0 ? Base.centralize_sumabs2(X.values, m, 1, n) :
+        /(nnull == 0 ? Nullable(Base.centralize_sumabs2(X.values, m, 1, n)) :
                        mapreduce_impl_skipnull(Base.CentralizedAbs2Fun(m),
                                                Base.AddFun(), X),
           Nullable(n - nnull - Int(corrected))

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -3,46 +3,56 @@ module TestReduce
     using Base.Test
 
     srand(1)
-    A = rand(10)
-    M = rand(Bool, 10)
-    M[rand(1:5)] = true
-    M[rand(6:10)] = false
-    X = NullableArray(A)
-    Y = NullableArray(A, M)
-    B = A[find(x->!x, M)]
     f(x) = 5 * x
     f{T<:Number}(x::Nullable{T}) = Nullable(5 * x.value, x.isnull)
 
-    @test isequal(mapreduce(f, +, X), Nullable(mapreduce(f, +, X.values)))
-    @test isequal(mapreduce(f, +, Y), Nullable{Float64}())
-    @test isequal(mapreduce(f, +, Y, skipnull=true),
-                  Nullable(mapreduce(f, +, B)))
+    for N in (10, 100)
+        A = rand(N)
+        M = rand(Bool, N)
+        i = rand(1:N)
+        M[i] = true
+        j = rand(1:N)
+        while j == i
+            j = rand(1:N)
+        end
+        M[j] = false
+        X = NullableArray(A)
+        Y = NullableArray(A, M)
+        B = A[find(x->!x, M)]
 
-    @test isequal(reduce(+, X), Nullable(reduce(+, X.values)))
-    @test isequal(reduce(+, Y), Nullable{Float64}())
-    @test isequal(reduce(+, Y, skipnull=true),
-                Nullable(reduce(+, B)))
+        @test isequal(mapreduce(f, +, X), Nullable(mapreduce(f, +, X.values)))
+        @test isequal(mapreduce(f, +, Y), Nullable{Float64}())
+        @test isequal(mapreduce(f, +, Y, skipnull=true),
+                      Nullable(mapreduce(f, +, B)))
 
-    for method in (
-        sum,
-        prod,
-        minimum,
-        maximum,
-    )
-        @test isequal(method(X), Nullable(method(A)))
-        @test isequal(method(f, X), Nullable(method(f, A)))
-        @test isequal(method(Y), Nullable{Float64}())
-        @test isequal(method(Y, skipnull=true), Nullable(method(B)))
-        @test isequal(method(f, Y), Nullable{Float64}())
-        @test isequal(method(f, Y, skipnull=true), Nullable(method(f, B)))
-    end
+        @test isequal(reduce(+, X), Nullable(reduce(+, X.values)))
+        @test isequal(reduce(+, Y), Nullable{Float64}())
+        @test isequal(reduce(+, Y, skipnull=true),
+                    Nullable(reduce(+, B)))
 
-    for method in (
-        sumabs,
-        sumabs2,
-    )
-        @test isequal(method(X), Nullable(method(A)))
-        @test isequal(method(Y), Nullable{Float64}())
-        @test isequal(method(Y, skipnull=true), Nullable(method(B)))
+        for method in (
+            sum,
+            prod,
+            minimum,
+            maximum,
+        )
+            @test isequal(method(X), Nullable(method(A)))
+            @test isequal(method(f, X), Nullable(method(f, A)))
+            @test isequal(method(Y), Nullable{Float64}())
+            @test isequal(method(Y, skipnull=true), Nullable(method(B)))
+            @test isequal(method(f, Y), Nullable{Float64}())
+            @test isequal(method(f, Y, skipnull=true), Nullable(method(f, B)))
+        end
+
+        for method in (
+            sumabs,
+            sumabs2,
+        )
+            @test isequal(method(X), Nullable(method(A)))
+            @test isequal(method(Y), Nullable{Float64}())
+            v = method(Y, skipnull=true)
+            @test_approx_eq v.value method(B)
+            @test v.isnull == false
+        end
     end
 end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -4,167 +4,176 @@ module TestStatistics
     using Base.Test
 
     srand(1)
-    A = rand(10)
-    M = rand(Bool, 10)
-    mu_A = mean(A)
-    nmu_A = Nullable(mu_A)
-    i = rand(1:10)
-    M[rand(1:5)] = true
-    j = rand(1:10)
-    while j == i
-        j = rand(1:10)
+
+    for N in (10, 100)
+        A = rand(N)
+        M = rand(Bool, N)
+        mu_A = mean(A)
+        nmu_A = Nullable(mu_A)
+        i = rand(1:N)
+        M[i] = true
+        j = rand(1:N)
+        while j == i
+            j = rand(1:N)
+        end
+        M[j] = false
+        X = NullableArray(A)
+        Y = NullableArray(A, M)
+        B = A[find(x->!x, M)]
+        mu_B = mean(B)
+        nmu_B = Nullable(mu_B)
+
+        C = rand(N)
+        V = WeightVec(C)
+        R = rand(Bool, N)
+        R[rand(1:N)] = true
+        R[j] = false
+        # W = WeightVec(NullableArray(C, R))
+
+        J = find(i -> (!M[i] & !R[i]), [1:N...])
+
+        # Test mean methods
+        @test isequal(mean(X), Nullable(mean(A)))
+        @test isequal(mean(Y), Nullable{Float64}())
+        v = mean(Y, skipnull=true)
+        @test_approx_eq v.value mean(B)
+        @test !v.isnull
+        @test isequal(mean(X, V), Nullable(mean(A, V)))
+        # Following tests need to wait until WeightVec constructor is implemented
+        # for NullableArray argument
+        # @test isequal(mean(X, W), Nullable{Float64}())
+        # @test isequal(mean(X, W, skipnull=true), Nullable(mean(A[J], WeightVec(C[J]))))
+
+        # Test varm methods
+        @test isequal(varm(X, mu_A), Nullable(varm(A, mu_A)))
+        @test isequal(varm(X, mu_A, corrected=false),
+                      Nullable(varm(A, mu_A, corrected=false)))
+        @test isequal(varm(Y, mu_B), Nullable{Float64}())
+        @test isequal(varm(Y, mu_B, corrected=false), Nullable{Float64}())
+        @test isequal(varm(Y, mu_B, skipnull=true),
+                      Nullable(varm(B, mu_B)))
+        @test isequal(varm(Y, mu_B, corrected=false, skipnull=true),
+                      Nullable(varm(B, mu_B, corrected=false)))
+
+        @test isequal(varm(X, nmu_A), Nullable(varm(A, mu_A)))
+        @test isequal(varm(X, nmu_A, corrected=false),
+                      Nullable(varm(A, mu_A, corrected=false)))
+        @test isequal(varm(Y, nmu_B), Nullable{Float64}())
+        @test isequal(varm(Y, nmu_B, corrected=false), Nullable{Float64}())
+        @test isequal(varm(Y, nmu_B, skipnull=true),
+                      Nullable(varm(B, mu_B)))
+        @test isequal(varm(Y, nmu_B, corrected=false, skipnull=true),
+                      Nullable(varm(B, mu_B, corrected=false)))
+
+        @test_throws NullException varm(Y, Nullable{Float64}())
+
+        # Test Base.varzm
+        D1 = rand(round(Int, N / 2))
+        D2 = -1 .* D1
+        D = [D1; D2]
+        while mean(D) != 0
+            D1 = rand(round(Int, N / 2))
+            D2 = -1 .* D1
+            D = [D1; D2]
+        end
+        Q = NullableArray(D)
+        S = rand(Bool, round(Int, N / 2))
+        U = NullableArray(D, [S; S])
+        E = [D[find(x->!x, S)]; D[find(x->!x, S)]]
+
+        @test isequal(Base.varzm(Q), Nullable(Base.varzm(D)))
+        @test isequal(Base.varzm(Q, corrected=false),
+                      Nullable(Base.varzm(D, corrected=false)))
+        @test isequal(Base.varzm(U), Nullable{Float64}())
+        @test isequal(Base.varzm(U, corrected=false), Nullable{Float64}())
+        @test isequal(Base.varzm(U, skipnull=true),
+                      Nullable(Base.varzm(E)))
+        @test isequal(Base.varzm(U, corrected=false, skipnull=true),
+                      Nullable(Base.varzm(E, corrected=false)))
+
+        # Test var
+        @test isequal(var(X), Nullable(var(A)))
+        @test isequal(var(X, corrected=false), Nullable(var(A, corrected=false)))
+        @test isequal(var(X, mean=mu_A), Nullable(var(A, mean=mu_A)))
+        @test isequal(var(X, mean=nmu_A), Nullable(var(A, mean=mu_A)))
+        @test isequal(var(X, mean=mu_A, corrected=false),
+                      Nullable(var(A, mean=mu_A, corrected=false)))
+        @test isequal(var(X, mean=nmu_A, corrected=false),
+                      Nullable(var(A, mean=mu_A, corrected=false)))
+
+        @test isequal(var(Y), Nullable{Float64}())
+        @test isequal(var(Y, corrected=false), Nullable{Float64}())
+        @test isequal(var(Y, mean=mu_B), Nullable{Float64}())
+        @test isequal(var(Y, mean=nmu_B), Nullable{Float64}())
+        @test isequal(var(Y, mean=mu_B, corrected=false),
+                      Nullable{Float64}())
+        @test isequal(var(Y, mean=nmu_B, corrected=false),
+                      Nullable{Float64}())
+
+        @test isequal(var(Y, skipnull=true),
+                      Nullable(var(B)))
+        @test isequal(var(Y, corrected=false, skipnull=true),
+                      Nullable(var(B, corrected=false)))
+        @test isequal(var(Y, mean=mu_B, skipnull=true),
+                      Nullable(var(B, mean=mu_B)))
+        @test isequal(var(Y, mean=nmu_B, skipnull=true),
+                      Nullable(var(B, mean=mu_B)))
+        @test isequal(var(Y, mean=mu_B, corrected=false, skipnull=true),
+                      Nullable(var(B, mean=mu_B, corrected=false)))
+        @test isequal(var(Y, mean=nmu_B, corrected=false, skipnull=true),
+                      Nullable(var(B, mean=mu_B, corrected=false)))
+
+        # Test stdm
+        @test isequal(stdm(X, mu_A), Nullable(stdm(A, mu_A)))
+        @test isequal(stdm(X, mu_A, corrected=false),
+                      Nullable(stdm(A, mu_A, corrected=false)))
+        @test isequal(stdm(Y, mu_B), Nullable{Float64}())
+        @test isequal(stdm(Y, mu_B, corrected=false), Nullable{Float64}())
+        @test isequal(stdm(Y, mu_B, skipnull=true),
+                      Nullable(stdm(B, mu_B)))
+        @test isequal(stdm(Y, mu_B, corrected=false, skipnull=true),
+                      Nullable(stdm(B, mu_B, corrected=false)))
+
+        @test isequal(stdm(X, nmu_A), Nullable(stdm(A, mu_A)))
+        @test isequal(stdm(X, nmu_A, corrected=false),
+                      Nullable(stdm(A, mu_A, corrected=false)))
+        @test isequal(stdm(Y, nmu_B), Nullable{Float64}())
+        @test isequal(stdm(Y, nmu_B, corrected=false), Nullable{Float64}())
+        @test isequal(stdm(Y, nmu_B, skipnull=true),
+                      Nullable(stdm(B, mu_B)))
+        @test isequal(stdm(Y, nmu_B, corrected=false, skipnull=true),
+                      Nullable(stdm(B, mu_B, corrected=false)))
+
+        # Test std
+        @test isequal(std(X), Nullable(std(A)))
+        @test isequal(std(X, corrected=false), Nullable(std(A, corrected=false)))
+        @test isequal(std(X, mean=mu_A), Nullable(std(A, mean=mu_A)))
+        @test isequal(std(X, mean=nmu_A), Nullable(std(A, mean=mu_A)))
+        @test isequal(std(X, mean=mu_A, corrected=false),
+                      Nullable(std(A, mean=mu_A, corrected=false)))
+        @test isequal(std(X, mean=nmu_A, corrected=false),
+                      Nullable(std(A, mean=mu_A, corrected=false)))
+
+        @test isequal(std(Y), Nullable{Float64}())
+        @test isequal(std(Y, corrected=false), Nullable{Float64}())
+        @test isequal(std(Y, mean=mu_B), Nullable{Float64}())
+        @test isequal(std(Y, mean=nmu_B), Nullable{Float64}())
+        @test isequal(std(Y, mean=mu_B, corrected=false),
+                      Nullable{Float64}())
+        @test isequal(std(Y, mean=nmu_B, corrected=false),
+                      Nullable{Float64}())
+
+        @test isequal(std(Y, skipnull=true),
+                      Nullable(std(B)))
+        @test isequal(std(Y, corrected=false, skipnull=true),
+                      Nullable(std(B, corrected=false)))
+        @test isequal(std(Y, mean=mu_B, skipnull=true),
+                      Nullable(std(B, mean=mu_B)))
+        @test isequal(std(Y, mean=nmu_B, skipnull=true),
+                      Nullable(std(B, mean=mu_B)))
+        @test isequal(std(Y, mean=mu_B, corrected=false, skipnull=true),
+                      Nullable(std(B, mean=mu_B, corrected=false)))
+        @test isequal(std(Y, mean=nmu_B, corrected=false, skipnull=true),
+                      Nullable(std(B, mean=mu_B, corrected=false)))
     end
-    M[j] = false
-    X = NullableArray(A)
-    Y = NullableArray(A, M)
-    B = A[find(x->!x, M)]
-    mu_B = mean(B)
-    nmu_B = Nullable(mu_B)
-
-    C = rand(10)
-    V = WeightVec(C)
-    R = rand(Bool, 10)
-    R[rand(1:10)] = true
-    R[j] = false
-    # W = WeightVec(NullableArray(C, R))
-
-    J = find(i -> (!M[i] & !R[i]), [1:10...])
-
-    # Test mean methods
-    @test isequal(mean(X), Nullable(mean(A)))
-    @test isequal(mean(Y), Nullable{Float64}())
-    @test isequal(mean(Y, skipnull=true), Nullable(mean(B)))
-    @test isequal(mean(X, V), Nullable(mean(A, V)))
-    # Following tests need to wait until WeightVec constructor is implemented
-    # for NullableArray argument
-    # @test isequal(mean(X, W), Nullable{Float64}())
-    # @test isequal(mean(X, W, skipnull=true), Nullable(mean(A[J], WeightVec(C[J]))))
-
-    # Test varm methods
-    @test isequal(varm(X, mu_A), Nullable(varm(A, mu_A)))
-    @test isequal(varm(X, mu_A, corrected=false),
-                  Nullable(varm(A, mu_A, corrected=false)))
-    @test isequal(varm(Y, mu_B), Nullable{Float64}())
-    @test isequal(varm(Y, mu_B, corrected=false), Nullable{Float64}())
-    @test isequal(varm(Y, mu_B, skipnull=true),
-                  Nullable(varm(B, mu_B)))
-    @test isequal(varm(Y, mu_B, corrected=false, skipnull=true),
-                  Nullable(varm(B, mu_B, corrected=false)))
-
-    @test isequal(varm(X, nmu_A), Nullable(varm(A, mu_A)))
-    @test isequal(varm(X, nmu_A, corrected=false),
-                  Nullable(varm(A, mu_A, corrected=false)))
-    @test isequal(varm(Y, nmu_B), Nullable{Float64}())
-    @test isequal(varm(Y, nmu_B, corrected=false), Nullable{Float64}())
-    @test isequal(varm(Y, nmu_B, skipnull=true),
-                  Nullable(varm(B, mu_B)))
-    @test isequal(varm(Y, nmu_B, corrected=false, skipnull=true),
-                  Nullable(varm(B, mu_B, corrected=false)))
-
-    @test_throws NullException varm(Y, Nullable{Float64}())
-
-    # Test Base.varzm
-    D1 = rand(5)
-    D2 = -1 .* D1
-    D = [D1; D2]
-    @test mean(D) == 0
-    Q = NullableArray(D)
-    S = rand(Bool, 5)
-    U = NullableArray(D, [S; S])
-    E = [D[find(x->!x, S)]; D[find(x->!x, S)]]
-
-    @test isequal(Base.varzm(Q), Nullable(Base.varzm(D)))
-    @test isequal(Base.varzm(Q, corrected=false),
-                  Nullable(Base.varzm(D, corrected=false)))
-    @test isequal(Base.varzm(U), Nullable{Float64}())
-    @test isequal(Base.varzm(U, corrected=false), Nullable{Float64}())
-    @test isequal(Base.varzm(U, skipnull=true),
-                  Nullable(Base.varzm(E)))
-    @test isequal(Base.varzm(U, corrected=false, skipnull=true),
-                  Nullable(Base.varzm(E, corrected=false)))
-
-    # Test var
-    @test isequal(var(X), Nullable(var(A)))
-    @test isequal(var(X, corrected=false), Nullable(var(A, corrected=false)))
-    @test isequal(var(X, mean=mu_A), Nullable(var(A, mean=mu_A)))
-    @test isequal(var(X, mean=nmu_A), Nullable(var(A, mean=mu_A)))
-    @test isequal(var(X, mean=mu_A, corrected=false),
-                  Nullable(var(A, mean=mu_A, corrected=false)))
-    @test isequal(var(X, mean=nmu_A, corrected=false),
-                  Nullable(var(A, mean=mu_A, corrected=false)))
-
-    @test isequal(var(Y), Nullable{Float64}())
-    @test isequal(var(Y, corrected=false), Nullable{Float64}())
-    @test isequal(var(Y, mean=mu_B), Nullable{Float64}())
-    @test isequal(var(Y, mean=nmu_B), Nullable{Float64}())
-    @test isequal(var(Y, mean=mu_B, corrected=false),
-                  Nullable{Float64}())
-    @test isequal(var(Y, mean=nmu_B, corrected=false),
-                  Nullable{Float64}())
-
-    @test isequal(var(Y, skipnull=true),
-                  Nullable(var(B)))
-    @test isequal(var(Y, corrected=false, skipnull=true),
-                  Nullable(var(B, corrected=false)))
-    @test isequal(var(Y, mean=mu_B, skipnull=true),
-                  Nullable(var(B, mean=mu_B)))
-    @test isequal(var(Y, mean=nmu_B, skipnull=true),
-                  Nullable(var(B, mean=mu_B)))
-    @test isequal(var(Y, mean=mu_B, corrected=false, skipnull=true),
-                  Nullable(var(B, mean=mu_B, corrected=false)))
-    @test isequal(var(Y, mean=nmu_B, corrected=false, skipnull=true),
-                  Nullable(var(B, mean=mu_B, corrected=false)))
-
-    # Test stdm
-    @test isequal(stdm(X, mu_A), Nullable(stdm(A, mu_A)))
-    @test isequal(stdm(X, mu_A, corrected=false),
-                  Nullable(stdm(A, mu_A, corrected=false)))
-    @test isequal(stdm(Y, mu_B), Nullable{Float64}())
-    @test isequal(stdm(Y, mu_B, corrected=false), Nullable{Float64}())
-    @test isequal(stdm(Y, mu_B, skipnull=true),
-                  Nullable(stdm(B, mu_B)))
-    @test isequal(stdm(Y, mu_B, corrected=false, skipnull=true),
-                  Nullable(stdm(B, mu_B, corrected=false)))
-
-    @test isequal(stdm(X, nmu_A), Nullable(stdm(A, mu_A)))
-    @test isequal(stdm(X, nmu_A, corrected=false),
-                  Nullable(stdm(A, mu_A, corrected=false)))
-    @test isequal(stdm(Y, nmu_B), Nullable{Float64}())
-    @test isequal(stdm(Y, nmu_B, corrected=false), Nullable{Float64}())
-    @test isequal(stdm(Y, nmu_B, skipnull=true),
-                  Nullable(stdm(B, mu_B)))
-    @test isequal(stdm(Y, nmu_B, corrected=false, skipnull=true),
-                  Nullable(stdm(B, mu_B, corrected=false)))
-
-    # Test std
-    @test isequal(std(X), Nullable(std(A)))
-    @test isequal(std(X, corrected=false), Nullable(std(A, corrected=false)))
-    @test isequal(std(X, mean=mu_A), Nullable(std(A, mean=mu_A)))
-    @test isequal(std(X, mean=nmu_A), Nullable(std(A, mean=mu_A)))
-    @test isequal(std(X, mean=mu_A, corrected=false),
-                  Nullable(std(A, mean=mu_A, corrected=false)))
-    @test isequal(std(X, mean=nmu_A, corrected=false),
-                  Nullable(std(A, mean=mu_A, corrected=false)))
-
-    @test isequal(std(Y), Nullable{Float64}())
-    @test isequal(std(Y, corrected=false), Nullable{Float64}())
-    @test isequal(std(Y, mean=mu_B), Nullable{Float64}())
-    @test isequal(std(Y, mean=nmu_B), Nullable{Float64}())
-    @test isequal(std(Y, mean=mu_B, corrected=false),
-                  Nullable{Float64}())
-    @test isequal(std(Y, mean=nmu_B, corrected=false),
-                  Nullable{Float64}())
-
-    @test isequal(std(Y, skipnull=true),
-                  Nullable(std(B)))
-    @test isequal(std(Y, corrected=false, skipnull=true),
-                  Nullable(std(B, corrected=false)))
-    @test isequal(std(Y, mean=mu_B, skipnull=true),
-                  Nullable(std(B, mean=mu_B)))
-    @test isequal(std(Y, mean=nmu_B, skipnull=true),
-                  Nullable(std(B, mean=mu_B)))
-    @test isequal(std(Y, mean=mu_B, corrected=false, skipnull=true),
-                  Nullable(std(B, mean=mu_B, corrected=false)))
-    @test isequal(std(Y, mean=nmu_B, corrected=false, skipnull=true),
-                  Nullable(std(B, mean=mu_B, corrected=false)))
 end


### PR DESCRIPTION
Both methods were automatically skipping null entries, regardless of the value of `skipnull`, for `X::NullableArray` arguments of length > 16.

This behavior was due to the respective `Base.mapreduce_impl` methods, which I had implemented before the `_mapreduce_skipnull` interface.

The previous tests did not catch this behavior because they did not test mapreduce-related methods on argument `NullableArray`s of length > 16. These tests, and tests for `src/statistics.jl` are updated accordingly.

2nd commit:
I've revised the tests in `test/statistics.jl` to better cope with floating point rounding errors that appear to be more of a problem after the fixes in the previous commit. I don't know if that's coincidence (the `mapreduce.jl` and `statistics.jl` are both fairly new, so perhaps it was just a matter of time until such errors materialized) or if the fix in the previous comment is the direct cause. In any case, tests appear to be passing now.

Revising the tests also uncovered a bug in `varm(X, skipnull=true)` when `X` has 0 null entries. That's fixed in the 2nd commit. 
