### PR TITLE
Tests

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -72,7 +72,7 @@ function Base.var(X::NullableArray; corrected::Bool=true, mean=nothing,
 
     (anynull(X) & !skipnull) && return Nullable{eltype(X)}()
 
-    if mean == 0 || (isa(mean, Nullable) && get(mean == Nullable(0)))
+    if mean == 0 || isequal(mean, Nullable(0))
         return Base.varzm(X; corrected=corrected, skipnull=skipnull)
     elseif mean == nothing
         return varm(X, Base.mean(X; skipnull=skipnull); corrected=corrected,


### PR DESCRIPTION
Mostly test revisions for added coverage, with a slight revision to `src/statistics.jl`. The one line change simply revised a condition that was semantically valid but made no sense for its purpose. The only reason previous tests didn't catch this issue is that if the condition was not met, then the method simply fell back on computing the variance the long way around as opposed to calling `varzm`. 
