### PR TITLE
Begin overhaul of profiling suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ julia:
     - nightly
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.init(); Pkg.clone(pwd())'
+    - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.clone("https://github.com/johnmyleswhite/Benchmarks.jl.git")'
     - julia -e 'Pkg.test("NullableArrays", coverage=true)'
 after_success:
     - julia -e 'cd(Pkg.dir("NullableArrays")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/perf/BenchmarkUtils.jl
+++ b/perf/BenchmarkUtils.jl
@@ -1,0 +1,103 @@
+module BenchmarkUtils
+
+using Benchmarks
+
+function Base.writecsv(file::AbstractString, profiler, s::Benchmarks.Samples,
+                  e::Benchmarks.Environment, append::Bool = false,
+                  delim::Char = '\t', header::Bool = true)
+    if append
+        io = open(file, "a")
+    else
+        io = open(file, "w")
+    end
+    if header
+        println(
+            io,
+            join(
+                [
+                    "env_uuid",
+                    "op_name",
+                    "n_nulls",
+                    "skipnull",
+                    "n_evals",
+                    "elapsed_times",
+                    "bytes_allocated",
+                    "gc_times",
+                    "num_allocations",
+                ],
+                delim
+            )
+        )
+    end
+    for i in 1:length(s.n_evals)
+        println(
+            io,
+            join(
+                [
+                    string(e.uuid),
+                    string(profiler[2]),
+                    string(profiler[3]),
+                    string(profiler[4]),
+                    string(s.n_evals[i]),
+                    string(s.elapsed_times[i]),
+                    string(s.bytes_allocated[i]),
+                    string(s.gc_times[i]),
+                    string(s.num_allocations[i]),
+                ],
+                delim
+            )
+        )
+    end
+    close(io)
+end
+
+function Base.writecsv(filename::String, e::Benchmarks.Environment,
+                       append::Bool = false, delim::Char = '\t',
+                       header::Bool = true)
+    if append
+        io = open(filename, "a")
+    else
+        io = open(filename, "w")
+    end
+    if header
+        println(
+            io,
+            join(
+                [
+                    "uuid",
+                    "timestamp",
+                    "julia_sha1",
+                    "package_sha1",
+                    "os",
+                    "cpu_cores",
+                    "arch",
+                    "machine",
+                    "use_blas64",
+                    "word_size",
+                ],
+                delim
+            )
+        )
+    end
+    println(
+        io,
+        join(
+            [
+                e.uuid,
+                e.timestamp,
+                e.julia_sha1,
+                get(e.package_sha1, "NULL"),
+                e.os,
+                string(e.cpu_cores),
+                e.arch,
+                e.machine,
+                string(e.use_blas64),
+                string(e.word_size),
+            ],
+            delim
+        )
+    )
+    close(io)
+end
+
+end # module BenchmarkUtils

--- a/res/broadcast.csv
+++ b/res/broadcast.csv
@@ -1,0 +1,1 @@
+env_uuid,op_name,n_nulls,skipnull,n_evals,elapsed_times,bytes_allocated,gc_times,num_allocations

--- a/res/env.csv
+++ b/res/env.csv
@@ -1,0 +1,1 @@
+uuid,timestamp,julia_sha1,package_sha1,os,cpu_cores,arch,machine,use_blas64,word_size

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -30,4 +30,7 @@ module NullableArrays
     include("reduce.jl")
     include("statistics.jl")
     include("show.jl")
+
+    pkg_dir = Pkg.dir("NullableArrays")
+    include(joinpath(pkg_dir, "perf/BenchmarkUtils.jl"))
 end


### PR DESCRIPTION
This PR introduces a new design for the performance benchmarking regimen used in this package. In particular, it introduces the requirement of @johnmyleswhite 's Benchmarks.jl and leverages the latter's interface to facilitate writing environment information and benchmark results to file.

Running `profile(n_samples, n_evals)` after including `perf/broadcast.jl` in a session will grab environmental data by creating a `Benchmarks.Environment` object and then write that information to `res/env.csv` which by default contains only the header information. `profile` will then run a number of benchmarking methods generated via `Benchmarks.@benchmarkable` and record the results to `res/broadcast.csv`, which likewise by default contains only header information. The results written to `res/broadcast.csv` include the UUID of the aforementioned `Environment` object, allowing individual benchmark results to be joined against environment information.

I'm still working out the best way to make this interface generic across all profiling tests, which data to record and the best way to write them to file. I appreciate all suggestions on the matter.
