### PR TITLE
Fix warnings when loading NullableArrays module

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -88,12 +88,12 @@ end
 # implementations use convert(::Type{Bool}, ::Nullable{Bool}), but this is
 # slower.
 for (op, scalar_op) in (
-    (:.==, :(==)),
-    (:.!=, :!=),
-    (:.<, :<),
-    (:.>, :>),
-    (:.<=, :<=),
-    (:.>=, :>=)
+    (:(Base.(:(.==))), :(==)),
+    (:(Base.(:.!=)), :!=),
+    (:(Base.(:.<)), :<),
+    (:(Base.(:.>)), :>),
+    (:(Base.(:.<=)), :<=),
+    (:(Base.(:.>=)), :>=)
 )
     @eval begin
         ($op)(X::NullableArray, Y::NullableArray) = broadcast($scalar_op, X, Y)

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -90,6 +90,17 @@ function Base.mapreduce(f, op::Function, X::NullableArray;
     end
 end
 
+# to fix ambiguity warnings
+function Base.mapreduce(f, op::Union{Base.AndFun, Base.OrFun}, X::NullableArray,
+                        skipnull::Bool = false)
+    missingdata = anynull(X)
+    if skipnull
+        return _mapreduce_skipnull(f, op, X, missingdata)
+    else
+        return Base._mapreduce(f, op, X, missingdata)
+    end
+end
+
 function Base.mapreduce(f, op, X::NullableArray; skipnull::Bool = false)
     missingdata = anynull(X)
     if skipnull


### PR DESCRIPTION
Certain broadcasted operators incurred warnings during module loading due to not importing explicitly the operators from Base. `mapreduce` also incurred a method signature ambiguity warning. These changes fix the sources of these warnings.
