### PR TITLE
Show patch

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -126,16 +126,6 @@ function anynull(xs::NTuple) # -> Bool
     return anynull(collect(xs))
 end
 
-@generated function anynull{T, N, U<:NullableArray}(S::SubArray{T, N, U})
-    return quote
-        isnull = slice(S.parent.isnull, S.indexes...)
-        @nloops $N i S begin
-            (@nref $N isnull i) && (return true)
-        end
-        return false
-    end
-end
-
 # ----- allnull --------------------------------------------------------------#
 
 allnull(X::NullableArray) = all(X.isnull) # -> Bool
@@ -260,3 +250,8 @@ end
 
 # Use ready-made method for AbstractArrays or implement method specific to
 # NullableArrays, possibly for performance purposes?
+
+###
+
+Base.isnull(X::NullableArray, I::Int...) = X.isnull[I...]
+Base.values(X::NullableArray, I::Int...) = X.values[I...]

--- a/src/show.jl
+++ b/src/show.jl
@@ -11,7 +11,8 @@ end
 abstract NULL
 
 Base.showcompact(io::IO, ::Type{NULL}) = show(io, NULL)
-Base.show(io::IO, ::Type{NULL}) = print(io, "NULL")
+Base.show(io::IO, ::Type{NULL}) = print(io, "#NULL")
+Base.alignment(::Type{NULL}) = (5,0)
 
 function Base.show(io::IO, X::NullableArray)
     print(io, typeof(X))
@@ -59,8 +60,8 @@ function Base.show_delim_array(io::IO, X::NullableArray, op, delim, cl,
     print(io, cl)
 end
 
-function Base.alignment(
-    X::Union{NullableVector, NullableMatrix},
+function Base.alignment{T,N,U<:NullableArray}(
+    X::SubArray{T,N,U},
     rows::AbstractVector, cols::AbstractVector,
     cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
 )
@@ -69,10 +70,10 @@ function Base.alignment(
         l = r = 0
         for i in rows
             if isassigned(X,i,j)
-                if X.isnull[i, j]
+                if isnull(X, i, j)
                     aij = alignment(NULL)
                 else
-                    aij = alignment(X.values[i,j])
+                    aij = alignment(values(X, i,j))
                 end
             else
                 aij = undef_ref_alignment
@@ -94,6 +95,62 @@ function Base.alignment(
     return a
 end
 
+function Base.alignment(
+    X::Union{NullableArray, NullableMatrix},
+    rows::AbstractVector, cols::AbstractVector,
+    cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
+)
+    a = []
+    for j in cols
+        l = r = 0
+        for i in rows
+            if isassigned(X,i,j)
+                if isnull(X, i, j)
+                    aij = alignment(NULL)
+                else
+                    aij = alignment(values(X, i,j))
+                end
+            else
+                aij = undef_ref_alignment
+            end
+            l = max(l, aij[1])
+            r = max(r, aij[2])
+        end
+        push!(a, (l, r))
+        if length(a) > 1 && sum(map(sum,a)) + sep*length(a) >= cols_if_complete
+            pop!(a)
+            break
+        end
+    end
+    if 1 < length(a) < size(X,2)
+        while sum(map(sum,a)) + sep*length(a) >= cols_otherwise
+            pop!(a)
+        end
+    end
+    return a
+end
+
+function Base.print_matrix_row{T,N,P<:NullableArray}(io::IO,
+    X::SubArray{T,N,P}, A::Vector,
+    i::Integer, cols::AbstractVector, sep::AbstractString
+)
+    for k = 1:length(A)
+        j = cols[k]
+        if isassigned(X,i,j)
+            x = isnull(X,i,j) ? NULL : values(X,i,j)
+            a = alignment(x)
+            sx = sprint(showcompact_lim, x)
+        else
+            a = undef_ref_alignment
+            sx = undef_ref_str
+        end
+        l = repeat(" ", A[k][1]-a[1])
+        r = repeat(" ", A[k][2]-a[2])
+        print(io, l, sx, r)
+        if k < length(A); print(io, sep); end
+    end
+end
+
 function Base.print_matrix_row(io::IO,
     X::Union{NullableVector, NullableMatrix}, A::Vector,
     i::Integer, cols::AbstractVector, sep::AbstractString
@@ -101,7 +158,7 @@ function Base.print_matrix_row(io::IO,
     for k = 1:length(A)
         j = cols[k]
         if isassigned(X,i,j)
-            x = X.isnull[i,j] ? NULL : X.values[i,j]
+            x = isnull(X,i,j) ? NULL : values(X,i,j)
             a = alignment(x)
             sx = sprint(showcompact_lim, x)
         else

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,0 +1,46 @@
+
+const unsafe_getindex = Base.unsafe_getindex
+
+@generated function Base.isnull{T,N,P<:NullableArray,IV,LD}(V::SubArray{T,N,P,IV,LD}, I::Int...)
+    ni = length(I)
+    if ni == 1 && length(IV.parameters) == LD  # linear indexing
+        meta = Expr(:meta, :inline)
+        if iscontiguous(V)
+            return :($meta; Base.getindex(V.parent.isnull, V.first_index + I[1] - 1))
+        end
+        return :($meta; Base.getindex(V.parent.isnull, V.first_index + V.stride1*(I[1]-1)))
+    end
+    Isyms = [:(I[$d]) for d = 1:ni]
+    exhead, idxs = Base.index_generate(ndims(P), IV, :V, Isyms)
+    quote
+        $exhead
+        Base.getindex(V.parent.isnull, $(idxs...))
+    end
+end
+
+@generated function Base.values{T,N,P<:NullableArray,IV,LD}(V::SubArray{T,N,P,IV,LD}, I::Int...)
+    ni = length(I)
+    if ni == 1 && length(IV.parameters) == LD  # linear indexing
+        meta = Expr(:meta, :inline)
+        if iscontiguous(V)
+            return :($meta; Base.getindex(V.parent.values, V.first_index + I[1] - 1))
+        end
+        return :($meta; Base.getindex(V.parent.values, V.first_index + V.stride1*(I[1]-1)))
+    end
+    Isyms = [:(I[$d]) for d = 1:ni]
+    exhead, idxs = Base.index_generate(ndims(P), IV, :V, Isyms)
+    quote
+        $exhead
+        Base.getindex(V.parent.values, $(idxs...))
+    end
+end
+
+@generated function anynull{T, N, U<:NullableArray}(S::SubArray{T, N, U})
+    return quote
+        isnull = slice(S.parent.isnull, S.indexes...)
+        @nloops $N i S begin
+            (@nref $N isnull i) && (return true)
+        end
+        return false
+    end
+end


### PR DESCRIPTION
I've managed to pare down the code reuse necessary to get the custom show regime working for higher dimensional `NullableArray`s. There's still a frustrating duplication of the `Base.alignment` and `Base.print_matrix_row` methods -- one to show `NullableArray` arguments of dimension <2 and one to show `SubArray` arguments with `NullableArray` parents. In fact the method bodies are precisely the same, but I haven't been able to find a method signature that properly covers both argument signatures. The difficulty is that one needs to introduce type parameters in order to cover the `SubArray` case, thereby adding an extra layer of specificity to the methods. The additional specificity causes the `Base.display` method chain to fall back on the default `Base.alignment` and `Base.print_matrix_row` methods for `NullableArray` arguments.

Regardless, this is how it looks:

``` julia
julia> using NullableArrays

julia> A = reshape(1:16, 2, 2, 2, 2);

julia> X = NullableArray(A, rand(Bool, 2, 2, 2, 2))
2x2x2x2 NullableArray{Int64,4}:
[:, :, 1, 1] =
     1      3
 #NULL  #NULL

[:, :, 2, 1] =
 5  #NULL
 6  #NULL

[:, :, 1, 2] =
 #NULL  11
    10  12

[:, :, 2, 2] =
 #NULL  15
 #NULL  16

julia> X[:, :, 1, 1]
2x2 NullableArray{Int64,2}:
     1      3
 #NULL  #NULL

julia> X[:, 1, 1, 1]
2-element NullableArray{Int64,1}:
     1
 #NULL

julia> slice(X, :, :, :, 1)
2x2x2 SubArray{Nullable{Int64},3,NullableArray{Int64,4},Tuple{Colon,Colon,Colon,Int64},4}:
[:, :, 1] =
     1      3
 #NULL  #NULL

[:, :, 2] =
 5  #NULL
 6  #NULL

julia> slice(X, :, :, 1, 1)
2x2 SubArray{Nullable{Int64},2,NullableArray{Int64,4},Tuple{Colon,Colon,Int64,Int64},4}:
     1      3
 #NULL  #NULL
```

Fixes #57 
