### PR TITLE
Fix display behavior for undefined refs

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,4 +1,5 @@
-using Base: tty_size, alignment, print_matrix_row, strwidth, showcompact_lim
+using Base: tty_size, alignment, print_matrix_row, strwidth, showcompact_lim,
+            undef_ref_alignment, undef_ref_str
 
 type2string{T, N}(::Type{NullableArray{T, N}}) = "NullableArray{$T,$N}"
 type2string{T}(::Type{NullableArray{T}}) = "NullableArray{$T,N}"


### PR DESCRIPTION
Otherwise, showing a value of `NullableArray(Array(Any, n))` incurs an
error because certain names are not available.
