### PR TITLE
WIP: support NullableArrays conversions if #undef values are null

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -321,9 +321,25 @@ function Base.convert(::Type{NullableArray},
     return NullableArray(A)
 end
 
+function Base.convert{S, T, N}(::Type{NullableArray{S}},
+                               X::NullableArray{T, N}) # -> NullableArray{S, N}
+    res = similar(X, Nullable{S}, size(X))
+    for i in eachindex(X)
+        if !isassigned(X.values, i)
+            X.isnull[i] ? nothing : error()
+        else
+            res[i] = X[i]
+        end
+    end
+    return res
+end
+
 function Base.convert{S, T, N}(::Type{NullableArray{S, N}},
-                               A::NullableArray{T, N}) # -> NullableArray{S, N}
-    return NullableArray(convert(Array{S}, A.values), A.isnull)
+                               X::NullableArray{T, N}) # -> NullableArray{S, N}
+    res = NullableArray(convert(Array{S}, X.values), X.isnull)
+    # res2 = convert(NullableArray{S}, X)
+    # println(isequal(res, res2))
+    return res
 end
 
 @doc """

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -140,7 +140,7 @@ for (fn, op) in ((:(Base.sum), Base.AddFun()),
                  (:(Base.minimum), Base.MinFun()),
                  (:(Base.maximum), Base.MaxFun()))
     @eval begin
-        $fn(f::Union(Function,Base.Func{1}),
+        $fn(f::Union{Function,Base.Func{1}},
             X::NullableArray;
             skipnull::Bool = false) =
                 mapreduce(f, $op, X; skipnull = skipnull)


### PR DESCRIPTION
This PR is a pre-emptive fix for the issue described in https://github.com/JuliaStats/DataArrays.jl/issues/107. With it, the following works:

``` julia
julia> B = Array(Any, 8);

julia> X = NullableArray(B, fill(true, 8));

julia> X[2:8] = collect(2:8);

julia> convert(NullableArray{Float64}, X)
8-element NullableArray{Float64,1}:
 #NULL  
     2.0
     3.0
     4.0
     5.0
     6.0
     7.0
     8.0
```

HOWEVER, something strange is going on with the tests. Prior to the present PR, we only had a 

```
Base.convert{S, T, N}(::Type{NullableArray{S, N}}, X::NullableArray{T, N})
```

method. I added a

```
Base.convert{S, T, N}(::Type{NullableArray{S}}, X::NullableArray{T, N})
```

method, since the `N` parameter in the first argument is redundant. I coded the new behavior into this second method, and then tried defining the first method in terms of the second. For some reason, this causes tests in `test/map.jl` and _sometimes_ `test/subarray.jl` to fail -- even though the return value of the new methods are equal under `isequals` to the return values of the old methods. Leaving the first method as is but including the second, new method seems to pass just fine.

I'm going to continue trying to figure out what's wrong -- it may be a problem with the tests themselves. But this has really got me scratching my head, and if anybody has a lead I would appreciate it.
