### PR TITLE
Allow operations mixing Nullable and scalar

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -19,6 +19,40 @@ for f in (
 end
 
 # Implement the binary operators: +, -, *, /, %, &, |, ^, <<, and >>
+# Prevent ambiguities with Base
+@inline function Base.(:^){S1, S2<:Integer}(x::Nullable{S1}, y::S2)
+    if isbits(S1) & isbits(S2)
+        Nullable(^(x.value, y), x.isnull)
+    else
+        throw_error()
+    end
+end
+
+for f in (
+    :(Base.(:<<)),
+    :(Base.(:>>))
+)
+    @eval begin
+        @inline function $(f){S1}(x::Nullable{S1}, y::Int)
+            if isbits(S1)
+                Nullable($(f)(x.value, y), x.isnull)
+            else
+                throw_error()
+            end
+        end
+    end
+
+    @eval begin
+        @inline function $(f){S1, T<:Integer}(x::Nullable{S1}, y::T)
+            if isbits(S1) && isbits(T)
+                Nullable($(f)(x.value, y), x.isnull)
+            else
+                throw_error()
+            end
+        end
+    end
+end
+
 for f in (
     :(Base.(:+)),
     :(Base.(:-)),
@@ -40,21 +74,35 @@ for f in (
             end
         end
     end
+
+    @eval begin
+        @inline function $(f){S1, S2}(x::Nullable{S1}, y::S2)
+            if isbits(S1) & isbits(S2)
+                Nullable($(f)(x.value, y), x.isnull)
+            else
+                throw_error()
+            end
+        end
+    end
 end
 
 # Implement the binary operators: == and !=
-for f in (
-    :(Base.(:(==))),
-    :(Base.(:!=)),
-)
-    @eval begin
-        function $(f){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
-            if isbits(S1) & isbits(S2)
-                Nullable{Bool}($(f)(x.value, y.value), x.isnull | y.isnull)
-            else
-                error()
-            end
-        end
+# Prevent ambiguity with Base
+Base.(:(==))(x::Nullable, y::WeakRef) = x == y.value
+
+function Base.(:(==)){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
+    if isbits(S1) & isbits(S2)
+        Nullable{Bool}(x.value == y.value, x.isnull | y.isnull)
+    else
+        error()
+    end
+end
+
+function Base.(:(==)){S1, S2}(x::Nullable{S1}, y::S2)
+    if isbits(S1) & isbits(S2)
+        Nullable{Bool}(x.value == y, x.isnull)
+    else
+        error()
     end
 end
 
@@ -69,6 +117,16 @@ for f in (
         function $(f){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
             if isbits(S1) & isbits(S2)
                 Nullable{Bool}($(f)(x.value, y.value), x.isnull | y.isnull)
+            else
+                error()
+            end
+        end
+    end
+
+    @eval begin
+        function $(f){S1, S2}(x::Nullable{S1}, y::S2)
+            if isbits(S1) & isbits(S2)
+                Nullable{Bool}($(f)(x.value, y), x.isnull)
             else
                 error()
             end
@@ -103,6 +161,14 @@ function Base.sqrt{T}(x::Nullable{T})
 end
 
 ## Lifted functors
+
+function Base.call{S1, S2}(::Base.MinFun, x::Nullable{S1}, y::Nullable{S2})
+    if isbits(S1) & isbits(S2)
+        return Nullable(Base.scalarmin(x.value, y.value), x.isnull | y.isnull)
+    else
+        error()
+    end
+end
 
 function Base.call{S1, S2}(::Base.MinFun, x::Nullable{S1}, y::Nullable{S2})
     if isbits(S1) & isbits(S2)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -46,6 +46,9 @@ module TestOperators
         x = op(Nullable(v), Nullable(w))
         @test_approx_eq x.value op(v, w)
         @test !x.isnull
+        y = op(Nullable(v), w)
+        @test_approx_eq y.value op(v, w)
+        @test !y.isnull
         @test_throws ErrorException op(Nullable(rand(1)), Nullable(rand(1)))
     end
 
@@ -58,6 +61,9 @@ module TestOperators
         x = op(Nullable(v), Nullable(w))
         @test_approx_eq x.value op(v, w)
         @test !x.isnull
+        y = op(Nullable(v), w)
+        @test_approx_eq y.value op(v, w)
+        @test !y.isnull
         @test_throws ErrorException op(Nullable(rand(Bool, 1)), Nullable(rand(Bool, 1)))
     end
 
@@ -70,6 +76,9 @@ module TestOperators
         x = op(Nullable(v), Nullable(w))
         @test_approx_eq x.value op(v, w)
         @test !x.isnull
+        y = op(Nullable(v), w)
+        @test_approx_eq y.value op(v, w)
+        @test !y.isnull
         @test_throws ErrorException op(Nullable(rand(Int, 1)), Nullable(rand(Int, 1)))
     end
 end


### PR DESCRIPTION
Makes `op(y::Nullable, x)` equivalent to `op(y, Nullable(x))`, but more efficient.

I have played with the idea of actually defining `op(x::Nullable, y) = op(x, Nullable(y))`, hoping that the compiler would get rid of everything, but the generated code is awful.

The presence of ambiguities makes the code much longer than it needs to be. In particular, the ambiguous `<<` and `>>` in Base are only there to raise an error, and define something like an interface. We could imagine that with an improved support for traits they would no longer happen in some future release...
