### PR TITLE
Fix method error incurred by JuliaLang PR#13803

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -42,10 +42,9 @@ function gen_broadcast_body(nd::Int, narrays::Int, f, lift::Bool)
     end
 end
 
-function gen_broadcast_function(nd::Int, narrays::Int, f::Function, lift::Bool)
+function gen_broadcast_function(nd::Int, narrays::Int, f, lift::Bool)
     As = [symbol("A_"*string(i)) for i = 1:narrays]
     body = gen_broadcast_body(nd, narrays, f, lift)
-    # println(macroexpand( body ))
     @eval let
         local _F_
         function _F_(B, $(As...))

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -88,7 +88,11 @@ module TestIndexing
     Z_values = reshape(collect(1:125), (5,5,5))
     Z = NullableArray(Z_values)
 
-    @test isequal(Z[1, 1:4, 1], NullableArray{Int, 2}([1 6 11 16]))
+    if VERSION > v"0.5.0-dev+1195" # PR #13612 in JuliaLang
+        @test isequal(Z[1, 1:4, 1], NullableArray([1, 6, 11, 16]))
+    else
+        @test isequal(Z[1, 1:4, 1], NullableArray([1 6 11 16]))
+    end
 
     # getindex with AbstractVector{Bool}
     b = bitrand(10, 10)


### PR DESCRIPTION
Issue originally identified in https://github.com/JuliaLang/julia/pull/14186#issuecomment-160537192.

The issue is [here](https://github.com/JuliaLang/julia/pull/13803/files#diff-3377d917b3abf3efb064b20a9067a794R975). The argument signature of the internal `gen_broadcast_function` in the NullableArrays `broadcast` interface was [declared too restrictively](https://github.com/JuliaStats/NullableArrays.jl/blob/33e97108cd253d5e8e376265a58e92f2e6b93981/src/broadcast.jl#L45). Removing the `::Function` annotation from `f` fixes the problem.
