### PR TITLE
Fix issue #100, make work again with v0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4-
+Compat
 Reexport

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -1,34 +1,35 @@
 module NullableArrays
 
-    using Compat
-    using Reexport
-    @reexport using Base.Cartesian
+using Compat
+using Reexport
+@reexport using Base.Cartesian
 
-    export NullableArray,
-           NullableVector,
-           NullableMatrix,
+export NullableArray,
+       NullableVector,
+       NullableMatrix,
 
-           # Macros
+       # Macros
 
-           # Methods
-           dropnull,
-           anynull,
-           allnull,
-           head,
-           nullify!,
-           padnull!,
-           padnull,
-           tail
+       # Methods
+       dropnull,
+       anynull,
+       allnull,
+       head,
+       nullify!,
+       padnull!,
+       padnull,
+       tail
 
-    include("typedefs.jl")
-    include("constructors.jl")
-    include("primitives.jl")
-    include("indexing.jl")
-    include("map.jl")
-    include("nullablevector.jl")
-    include("operators.jl")
-    include("broadcast.jl")
-    include("reduce.jl")
-    include("show.jl")
-    include("subarray.jl")
+include("typedefs.jl")
+include("constructors.jl")
+include("primitives.jl")
+include("indexing.jl")
+include("map.jl")
+include("nullablevector.jl")
+include("operators.jl")
+include("broadcast.jl")
+include("reduce.jl")
+include("show.jl")
+include("subarray.jl")
+
 end

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -1,5 +1,6 @@
 module NullableArrays
 
+    using Compat
     using Reexport
     @reexport using Base.Cartesian
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -100,6 +100,5 @@ end
 # The following method allows for the construction of zero-element
 # NullableArrays by calling the parametrized type on zero arguments.
 # TODO: add support for dimensions arguments?
-function Base.call{T, N}(::Type{NullableArray{T, N}})
-    NullableArray(T, ntuple(i->0, N))
-end
+@compat (::Type{NullableArray{T, N}}){T, N}() = NullableArray(T, ntuple(i->0, N))
+

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -104,18 +104,18 @@ end
 
 ## Lifted functors
 
-function Base.call{S1, S2}(::Base.MinFun, x::Nullable{S1}, y::Nullable{S2})
+@compat function (::Base.MinFun){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
     if isbits(S1) & isbits(S2)
         return Nullable(Base.scalarmin(x.value, y.value), x.isnull | y.isnull)
     else
         error()
     end
 end
-
-function Base.call{S1, S2}(::Base.MaxFun, x::Nullable{S1}, y::Nullable{S2})
+@compat function (::Base.MaxFun){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
     if isbits(S1) & isbits(S2)
         return Nullable(Base.scalarmax(x.value, y.value), x.isnull | y.isnull)
     else
         error()
     end
 end
+

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,3 +1,6 @@
+if VERSION >= v"0.5.0-dev+2718"
+    include("subarray0_5.jl")
+else
 const unsafe_getindex = Base.unsafe_getindex
 
 @generated function Base.isnull{T,N,P<:NullableArray,IV,LD}(V::SubArray{T,N,P,IV,LD}, I::Int...)
@@ -32,6 +35,7 @@ end
         $exhead
         Base.getindex(V.parent.values, $(idxs...))
     end
+end
 end
 
 @generated function anynull{T, N, U<:NullableArray}(S::SubArray{T, N, U})

--- a/src/subarray0_5.jl
+++ b/src/subarray0_5.jl
@@ -1,0 +1,36 @@
+typealias NullableSubArray{T,N,P<:NullableArray,IV,LD} SubArray{T,N,P,IV,LD}
+
+@inline function Base.isnull(V::NullableSubArray, I::Int...)
+    @boundscheck checkbounds(V, I...)
+    @inbounds return V.parent.isnull[Base.reindex(V, V.indexes, I)...]
+end
+
+@inline function Base.values(V::NullableSubArray, I::Int...)
+    @boundscheck checkbounds(V, I...)
+    @inbounds return V.parent.values[Base.reindex(V, V.indexes, I)...]
+end
+
+typealias FastNullableSubArray{T,N,P<:NullableArray,IV} SubArray{T,N,P,IV,true}
+
+@inline function Base.isnull(V::FastNullableSubArray, i::Int)
+    @boundscheck checkbounds(V, i)
+    @inbounds return V.parent.isnull[V.first_index + V.stride1*i-1]
+end
+
+@inline function Base.values(V::FastNullableSubArray, i::Int)
+    @boundscheck checkbounds(V, i)
+    @inbounds return V.parent.values[V.first_index + V.stride1*i-1]
+end
+
+# We can avoid a multiplication if the first parent index is a Colon or UnitRange
+typealias FastNullableContiguousSubArray{T,N,P<:NullableArray,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}}} SubArray{T,N,P,I,true}
+
+@inline function Base.isnull(V::FastNullableContiguousSubArray, i::Int)
+    @boundscheck checkbounds(V, i)
+    @inbounds return V.parent.isnull[V.first_index + i - 1]
+end
+
+@inline function Base.values(V::FastNullableContiguousSubArray, i::Int)
+    @boundscheck checkbounds(V, i)
+    @inbounds return V.parent.values[V.first_index + i - 1]
+end


### PR DESCRIPTION
This fixes deprecations due to removal of `call` overloading,
and also fixes a problem with handling subarrays,
due to https://github.com/JuliaLang/julia/pull/15071 getting rid of the unexported `index_generate` function.
