### PR TITLE
Update show methods to Julia 0.5

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,277 +1,293 @@
-using Base: tty_size, alignment, print_matrix_row, strwidth, showcompact_lim,
-            undef_ref_alignment, undef_ref_str
+# No longer needed since https://github.com/JuliaLang/julia/pull/15928
+if VERSION >= v"0.5.0-dev+3610"
+    # Code similar to Base.show_vector()
+    function Base.show(io::IO, X::NullableVector)
+        print(io, typeof(X), "(")
+        if length(X) > 20
+            Base.show_delim_array(io, X, "[", ",", "", false, 1, 10)
+            print(io, "  …  ")
+            Base.show_delim_array(io, X, "", ",", "]", false, length(X)-9, 10)
+        else
+            Base.show_delim_array(io, X, "[", ",", "]", false)
+        end
+        print(io, ")")
+    end
+else
+    using Base: tty_size, alignment, print_matrix_row, strwidth, showcompact_lim,
+                undef_ref_alignment, undef_ref_str
 
-abstract NULL
+    function Base.show(io::IO, X::NullableArray)
+        print(io, typeof(X))
+        Base.show_vector(io, X, "[", "]")
+    end
 
-Base.showcompact(io::IO, ::Type{NULL}) = show(io, NULL)
-Base.show(io::IO, ::Type{NULL}) = print(io, "#NULL")
-Base.alignment(io::IO, ::Type{NULL}) = (5,0)
+    abstract NULL
 
-function Base.show(io::IO, X::NullableArray)
-    print(io, typeof(X))
-    Base.show_vector(io, X, "[", "]")
-end
+    Base.showcompact(io::IO, ::Type{NULL}) = show(io, NULL)
+    Base.show(io::IO, ::Type{NULL}) = print(io, "#NULL")
+    Base.alignment(io::IO, ::Type{NULL}) = (5,0)
 
-function Base.show_delim_array(io::IO, X::NullableArray, op, delim, cl,
-                               delim_one, compact=false, i1=1, l=length(X))
-    print(io, op)
-    newline = true
-    first = true
-    i = i1
-    if l > 0
-        while true
-            if !isassigned(X, i)
-                print(io, undef_ref_str)
-                multiline = false
-            else
-                x = X.isnull[i] ? NULL : X.values[i]
-                multiline = isa(x, AbstractArray) && ndims(x) > 1 && length(x) > 0
-                newline && multiline && println(io)
-                if !isbits(x) && is(x, X)
-                    print(io, "#= circular reference =#")
-                elseif compact
-                    showcompact_lim(io, x)
+    function Base.show_delim_array(io::IO, X::NullableArray, op, delim, cl,
+                                   delim_one, compact=false, i1=1, l=length(X))
+        print(io, op)
+        newline = true
+        first = true
+        i = i1
+        if l > 0
+            while true
+                if !isassigned(X, i)
+                    print(io, undef_ref_str)
+                    multiline = false
                 else
-                    show(io, x)
+                    x = X.isnull[i] ? NULL : X.values[i]
+                    multiline = isa(x, AbstractArray) && ndims(x) > 1 && length(x) > 0
+                    newline && multiline && println(io)
+                    if !isbits(x) && is(x, X)
+                        print(io, "#= circular reference =#")
+                    elseif compact
+                        showcompact_lim(io, x)
+                    else
+                        show(io, x)
+                    end
+                end
+                i += 1
+                if i > i1+l-1
+                    delim_one && first && print(io, delim)
+                    break
+                end
+                first = false
+                print(io, delim)
+                if multiline
+                    println(io); println(io)
+                    newline = false
+                else
+                    newline = true
                 end
             end
-            i += 1
-            if i > i1+l-1
-                delim_one && first && print(io, delim)
+        end
+        print(io, cl)
+    end
+
+    function Base.alignment{T,N,U<:NullableArray}(
+        io::IO, X::SubArray{T,N,U},
+        rows::AbstractVector, cols::AbstractVector,
+        cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
+    )
+        a = []
+        for j in cols
+            l = r = 0
+            for i in rows
+                if isassigned(X, i, j)
+                    if isnull(X, i, j)
+                        aij = alignment(io, NULL)
+                    else
+                        aij = alignment(io, values(X, i, j))
+                    end
+                else
+                    aij = undef_ref_alignment
+                end
+                l = max(l, aij[1])
+                r = max(r, aij[2])
+            end
+            push!(a, (l, r))
+            if length(a) > 1 && sum(map(sum, a)) + sep*length(a) >= cols_if_complete
+                pop!(a)
                 break
             end
-            first = false
-            print(io, delim)
-            if multiline
-                println(io); println(io)
-                newline = false
-            else
-                newline = true
+        end
+        if 1 < length(a) < size(X, 2)
+            while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
+                pop!(a)
             end
         end
+        return a
     end
-    print(io, cl)
-end
 
-function Base.alignment{T,N,U<:NullableArray}(
-    io::IO, X::SubArray{T,N,U},
-    rows::AbstractVector, cols::AbstractVector,
-    cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
-)
-    a = []
-    for j in cols
-        l = r = 0
-        for i in rows
-            if isassigned(X, i, j)
-                if isnull(X, i, j)
-                    aij = alignment(io, NULL)
+    function Base.alignment(
+        io::IO, X::Union{NullableArray, NullableMatrix},
+        rows::AbstractVector, cols::AbstractVector,
+        cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
+    )
+        a = []
+        for j in cols
+            l = r = 0
+            for i in rows
+                if isassigned(X, i, j)
+                    if isnull(X, i, j)
+                        aij = alignment(io, NULL)
+                    else
+                        aij = alignment(io, values(X, i, j))
+                    end
                 else
-                    aij = alignment(io, values(X, i, j))
+                    aij = undef_ref_alignment
                 end
-            else
-                aij = undef_ref_alignment
+                l = max(l, aij[1])
+                r = max(r, aij[2])
             end
-            l = max(l, aij[1])
-            r = max(r, aij[2])
+            push!(a, (l, r))
+            if length(a) > 1 && sum(map(sum,a)) + sep*length(a) >= cols_if_complete
+                pop!(a)
+                break
+            end
         end
-        push!(a, (l, r))
-        if length(a) > 1 && sum(map(sum, a)) + sep*length(a) >= cols_if_complete
-            pop!(a)
-            break
+        if 1 < length(a) < size(X, 2)
+            while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
+                pop!(a)
+            end
         end
+        return a
     end
-    if 1 < length(a) < size(X, 2)
-        while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
-            pop!(a)
-        end
-    end
-    return a
-end
 
-function Base.alignment(
-    io::IO, X::Union{NullableArray, NullableMatrix},
-    rows::AbstractVector, cols::AbstractVector,
-    cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
-)
-    a = []
-    for j in cols
-        l = r = 0
-        for i in rows
-            if isassigned(X, i, j)
-                if isnull(X, i, j)
-                    aij = alignment(io, NULL)
+    function Base.print_matrix_row{T,N,P<:NullableArray}(
+        io::IO, X::SubArray{T,N,P}, A::Vector,
+        i::Integer, cols::AbstractVector, sep::AbstractString
+    )
+        if VERSION < v"0.5.0-dev+1936" # compat issues from
+                                    # https://github.com/JuliaLang/julia/pull/13825
+            for k = 1:length(A)
+                j = cols[k]
+                if isassigned(X, i, j)
+                    x = isnull(X, i, j) ? NULL : values(X, i, j)
+                    a = alignment(x)
+                    sx = sprint(showcompact_lim, x)
                 else
-                    aij = alignment(io, values(X, i, j))
+                    a = undef_ref_alignment
+                    sx = undef_ref_str
                 end
-            else
-                aij = undef_ref_alignment
+                l = repeat(" ", A[k][1]-a[1])
+                r = repeat(" ", A[k][2]-a[2])
+                print(io, l, sx, r)
+                if k < length(A); print(io, sep); end
             end
-            l = max(l, aij[1])
-            r = max(r, aij[2])
-        end
-        push!(a, (l, r))
-        if length(a) > 1 && sum(map(sum,a)) + sep*length(a) >= cols_if_complete
-            pop!(a)
-            break
-        end
-    end
-    if 1 < length(a) < size(X, 2)
-        while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
-            pop!(a)
-        end
-    end
-    return a
-end
-
-function Base.print_matrix_row{T,N,P<:NullableArray}(
-    io::IO, X::SubArray{T,N,P}, A::Vector,
-    i::Integer, cols::AbstractVector, sep::AbstractString
-)
-    if VERSION < v"0.5.0-dev+1936" # compat issues from
-                                # https://github.com/JuliaLang/julia/pull/13825
-        for k = 1:length(A)
-            j = cols[k]
-            if isassigned(X, i, j)
-                x = isnull(X, i, j) ? NULL : values(X, i, j)
-                a = alignment(x)
-                sx = sprint(showcompact_lim, x)
-            else
-                a = undef_ref_alignment
-                sx = undef_ref_str
-            end
-            l = repeat(" ", A[k][1]-a[1])
-            r = repeat(" ", A[k][2]-a[2])
-            print(io, l, sx, r)
-            if k < length(A); print(io, sep); end
-        end
-    else
-        for k = 1:length(A)
-            j = cols[k]
-            if isassigned(X, i, j)
-                x = isnull(X, i, j) ? NULL : values(X, i, j)
-                a = alignment(io, x)
-                sx = sprint(showcompact_lim, x)
-            else
-                a = undef_ref_alignment
-                sx = undef_ref_str
-            end
-            l = repeat(" ", A[k][1]-a[1])
-            r = repeat(" ", A[k][2]-a[2])
-            print(io, l, sx, r)
-            if k < length(A); print(io, sep); end
-        end
-    end
-end
-
-function Base.print_matrix_row(io::IO,
-    X::Union{NullableVector, NullableMatrix}, A::Vector,
-    i::Integer, cols::AbstractVector, sep::AbstractString
-)
-    if VERSION < v"0.5.0-dev+1936" # compat issues from
-                                # https://github.com/JuliaLang/julia/pull/13825
-        for k = 1:length(A)
-            j = cols[k]
-            if isassigned(X, i, j)
-                x = isnull(X, i, j) ? NULL : values(X, i, j)
-                a = alignment(x)
-                sx = sprint(showcompact_lim, x)
-            else
-                a = undef_ref_alignment
-                sx = undef_ref_str
-            end
-            l = repeat(" ", A[k][1]-a[1])
-            r = repeat(" ", A[k][2]-a[2])
-            print(io, l, sx, r)
-            if k < length(A); print(io, sep); end
-        end
-    else
-        for k = 1:length(A)
-            j = cols[k]
-            if isassigned(X, i, j)
-                x = isnull(X, i, j) ? NULL : values(X, i, j)
-                a = alignment(io, x)
-                sx = sprint(showcompact_lim, x)
-            else
-                a = undef_ref_alignment
-                sx = undef_ref_str
-            end
-            l = repeat(" ", A[k][1]-a[1])
-            r = repeat(" ", A[k][2]-a[2])
-            print(io, l, sx, r)
-            if k < length(A); print(io, sep); end
-        end
-    end
-end
-
-# Methods for compatibility issues for VERSION < 0.5.0-dev+1936 stemming
-# from https://github.com/JuliaLang/julia/pull/13825
-
-Base.alignment(::Type{NULL}) = (5,0)
-function Base.alignment{T,N,U<:NullableArray}(
-    X::SubArray{T,N,U},
-    rows::AbstractVector, cols::AbstractVector,
-    cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
-)
-    a = []
-    for j in cols
-        l = r = 0
-        for i in rows
-            if isassigned(X, i, j)
-                if isnull(X, i, j)
-                    aij = alignment(NULL)
+        else
+            for k = 1:length(A)
+                j = cols[k]
+                if isassigned(X, i, j)
+                    x = isnull(X, i, j) ? NULL : values(X, i, j)
+                    a = alignment(io, x)
+                    sx = sprint(showcompact_lim, x)
                 else
-                    aij = alignment(values(X, i, j))
+                    a = undef_ref_alignment
+                    sx = undef_ref_str
                 end
-            else
-                aij = undef_ref_alignment
+                l = repeat(" ", A[k][1]-a[1])
+                r = repeat(" ", A[k][2]-a[2])
+                print(io, l, sx, r)
+                if k < length(A); print(io, sep); end
             end
-            l = max(l, aij[1])
-            r = max(r, aij[2])
-        end
-        push!(a, (l, r))
-        if length(a) > 1 && sum(map(sum, a)) + sep*length(a) >= cols_if_complete
-            pop!(a)
-            break
         end
     end
-    if 1 < length(a) < size(X, 2)
-        while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
-            pop!(a)
-        end
-    end
-    return a
-end
-function Base.alignment(
-    X::Union{NullableArray, NullableMatrix},
-    rows::AbstractVector, cols::AbstractVector,
-    cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
-)
-    a = []
-    for j in cols
-        l = r = 0
-        for i in rows
-            if isassigned(X, i, j)
-                if isnull(X, i, j)
-                    aij = alignment(NULL)
+
+    function Base.print_matrix_row(io::IO,
+        X::Union{NullableVector, NullableMatrix}, A::Vector,
+        i::Integer, cols::AbstractVector, sep::AbstractString
+    )
+        if VERSION < v"0.5.0-dev+1936" # compat issues from
+                                    # https://github.com/JuliaLang/julia/pull/13825
+            for k = 1:length(A)
+                j = cols[k]
+                if isassigned(X, i, j)
+                    x = isnull(X, i, j) ? NULL : values(X, i, j)
+                    a = alignment(x)
+                    sx = sprint(showcompact_lim, x)
                 else
-                    aij = alignment(values(X, i, j))
+                    a = undef_ref_alignment
+                    sx = undef_ref_str
                 end
-            else
-                aij = undef_ref_alignment
+                l = repeat(" ", A[k][1]-a[1])
+                r = repeat(" ", A[k][2]-a[2])
+                print(io, l, sx, r)
+                if k < length(A); print(io, sep); end
             end
-            l = max(l, aij[1])
-            r = max(r, aij[2])
-        end
-        push!(a, (l, r))
-        if length(a) > 1 && sum(map(sum,a)) + sep*length(a) >= cols_if_complete
-            pop!(a)
-            break
+        else
+            for k = 1:length(A)
+                j = cols[k]
+                if isassigned(X, i, j)
+                    x = isnull(X, i, j) ? NULL : values(X, i, j)
+                    a = alignment(io, x)
+                    sx = sprint(showcompact_lim, x)
+                else
+                    a = undef_ref_alignment
+                    sx = undef_ref_str
+                end
+                l = repeat(" ", A[k][1]-a[1])
+                r = repeat(" ", A[k][2]-a[2])
+                print(io, l, sx, r)
+                if k < length(A); print(io, sep); end
+            end
         end
     end
-    if 1 < length(a) < size(X, 2)
-        while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
-            pop!(a)
+
+    # Methods for compatibility issues for VERSION < 0.5.0-dev+1936 stemming
+    # from https://github.com/JuliaLang/julia/pull/13825
+
+    Base.alignment(::Type{NULL}) = (5,0)
+    function Base.alignment{T,N,U<:NullableArray}(
+        X::SubArray{T,N,U},
+        rows::AbstractVector, cols::AbstractVector,
+        cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
+    )
+        a = []
+        for j in cols
+            l = r = 0
+            for i in rows
+                if isassigned(X, i, j)
+                    if isnull(X, i, j)
+                        aij = alignment(NULL)
+                    else
+                        aij = alignment(values(X, i, j))
+                    end
+                else
+                    aij = undef_ref_alignment
+                end
+                l = max(l, aij[1])
+                r = max(r, aij[2])
+            end
+            push!(a, (l, r))
+            if length(a) > 1 && sum(map(sum, a)) + sep*length(a) >= cols_if_complete
+                pop!(a)
+                break
+            end
         end
+        if 1 < length(a) < size(X, 2)
+            while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
+                pop!(a)
+            end
+        end
+        return a
     end
-    return a
+    function Base.alignment(
+        X::Union{NullableArray, NullableMatrix},
+        rows::AbstractVector, cols::AbstractVector,
+        cols_if_complete::Integer, cols_otherwise::Integer, sep::Integer
+    )
+        a = []
+        for j in cols
+            l = r = 0
+            for i in rows
+                if isassigned(X, i, j)
+                    if isnull(X, i, j)
+                        aij = alignment(NULL)
+                    else
+                        aij = alignment(values(X, i, j))
+                    end
+                else
+                    aij = undef_ref_alignment
+                end
+                l = max(l, aij[1])
+                r = max(r, aij[2])
+            end
+            push!(a, (l, r))
+            if length(a) > 1 && sum(map(sum,a)) + sep*length(a) >= cols_if_complete
+                pop!(a)
+                break
+            end
+        end
+        if 1 < length(a) < size(X, 2)
+            while sum(map(sum, a)) + sep*length(a) >= cols_otherwise
+                pop!(a)
+            end
+        end
+        return a
+    end
 end


### PR DESCRIPTION
Since JuliaLang/julia#15928, Nullable() is printed as #NULL, which
means we no longer need to override show methods from Base.
This fixes breakage in current Julia 0.5.
Also fix a bug in show(), where NullableArray{T,N} was printed as the
element type prefix: add parentheses to make it clear this is the type
of the container.

Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/103. The diff is messy, but all I did is move the bottom of the file under the `else`, and add `show()` for 0.5. This means the day we'll drop support for 0.4, the file will be almost empty. Though since the printing code is being refactored in Base, we may well have to adjust this again; at some point, when things will have stabilized, we should try to rely only on public APIs, or copy `show_delim_array` (which is the only private function we use now).

There's a small regression/difference as regards the alignment of `#NULL`: it was previously aligned on the right, and it's now on the left. If that's considered a bad thing, we should make a simple PR against Base to add `alignment(::Nullable)`.
