### PR TITLE
Remove head() and tail()

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -14,11 +14,9 @@ export NullableArray,
        dropnull,
        anynull,
        allnull,
-       head,
        nullify!,
        padnull!,
-       padnull,
-       tail
+       padnull
 
 include("typedefs.jl")
 include("constructors.jl")

--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -1,20 +1,4 @@
 @doc """
-`head(X::NullableArray)`
-
-Returns the first six elements of `X` as a `NullableArray`. If `X` contains
-fewer than six elements, then this method returns `X`.
-""" ->
-head(X::NullableArray) = X[1:min(6, length(X))]
-
-@doc """
-`tail(X::NullableArray)`
-
-Returns the last six elements of `X` as a `NullableArray`. If `X` contains
-fewer than six elements, then this method returns `X`.
-""" ->
-tail(X::NullableArray) = X[max(1, length(X) - 5):length(X)]
-
-@doc """
 `push!{T, V}(X::NullableVector{T}, v::V)`
 
 Insert `v` at the end of `X`, which registers `v` as a present value.

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -8,10 +8,6 @@ module TestNullableVector
     X = NullableArray(A)
     Y = NullableArray(B)
 
-    #--- head/tail
-    @test isequal(head(X), NullableArray([1:6...]))
-    @test isequal(tail(X), NullableArray([5:10...]))
-
     #--- Base.push!
 
     # Base.push!{T, V}(X::NullableVector{T}, v::V)


### PR DESCRIPTION
These functions do not belong to NullableArrays, and they conflict
with DataArrays. They should live in Julia Base or a utilities
package.

I'm currently trying to port DataFrames to NullableArrays, and this creates conflict with DataArrays until I remove it completely.
