### PR TITLE
Fix convert(NullableArray, ::AbstractArray)

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -306,26 +306,6 @@ function Base.convert{T, N}(::Type{Array},
     return convert(Array{T, N}, X, replacement)
 end
 
-function Base.convert{S, T, N}(::Type{NullableArray{S, N}},
-                               A::AbstractArray{T, N}) # -> NullableArray{S, N}
-    return NullableArray(convert(Array{S, N}, A))
-end
-
-function Base.convert{S, T, N}(::Type{NullableArray{S}},
-                             A::AbstractArray{T, N}) # -> NullableArray{S, N}
-    return NullableArray(convert(Array{S, N}, A))
-end
-
-function Base.convert(::Type{NullableArray},
-                            A::AbstractArray) # -> NullableArray
-    return NullableArray(A)
-end
-
-function Base.convert{S, T, N}(::Type{NullableArray{S, N}},
-                               A::NullableArray{T, N}) # -> NullableArray{S, N}
-    return NullableArray(convert(Array{S}, A.values), A.isnull)
-end
-
 @doc """
 `float(X::NullableArray)`
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -5,7 +5,7 @@ module TestConstructors
     # test Inner Constructor
     @test_throws ArgumentError NullableArray([1, 2, 3, 4], [true, false, true])
 
-    # test Constructor #1
+    # test (A::AbstractArray, m::Array{Bool}) constructor
     v = [1, 2, 3, 4]
     dv = NullableArray(v, fill(false, size(v)))
 
@@ -23,14 +23,17 @@ module TestConstructors
     @test isa(y2, NullableVector{Int})
     @test y2.isnull[1]
 
-    # test Constructor #2
+    # test (::AbstractArray) constructor
     dv = NullableArray(v)
     @test isa(dv, NullableVector{Int})
 
     y = NullableArray([1, 2, 3, 4, 5, 6])
     @test isa(y, NullableVector{Int})
 
-    # test Constructor #3
+    z = NullableArray(1.:6.)
+    @test isa(z, NullableVector{Float64})
+
+    # test (::Type{T}, dims::Dims) constructor
     u1 = NullableArray(Int, (5, ))
     u2 = NullableArray(Int, (2, 2))
     u3 = NullableArray(Int, (2, 2, 2))
@@ -38,7 +41,7 @@ module TestConstructors
     @test isa(u2, NullableMatrix{Int})
     @test isa(u3, NullableArray{Int, 3})
 
-    # test Constructor #4
+    # test (::Type{T}, dims::Dims...) constructor
     x1 = NullableArray(Int, 2)
     x2 = NullableArray(Int, 2, 2)
     x3 = NullableArray(Int, 2, 2, 2)
@@ -46,13 +49,13 @@ module TestConstructors
     @test isa(x2, NullableMatrix{Int})
     @test isa(x3, NullableArray{Int, 3})
 
-    # test Constructor #5
+    # test (A::AbstractArray, ::Type{T}, ::Type{U}) constructor
     z = NullableArray([1, nothing, 2, nothing, 3], Int, Void)
     @test isa(z, NullableVector{Int})
     @test z.isnull[2]
     @test z.isnull[4]
 
-    # test Constructor #6
+    # test (A::AbstractArray, ::Type{T}, na::Any) constructor
     Z = NullableArray([1, "na", 2, 3, 4, 5, "na"], Int, "na")
     @test isa(Z, NullableVector{Int})
     @test Z.isnull == [false, true, false, false, false, false, true]
@@ -60,21 +63,39 @@ module TestConstructors
     Y = NullableArray([1, "na", 2, 3, 4, 5, "na"], Int, ASCIIString)
     @test isequal(Y, Z)
 
-    # test Constructor #7
+    # test parameterized type constructor with no arguments
     @test isequal(NullableVector{Int}(), NullableArray{Int, 1}([]))
     @test isequal(NullableArray{Bool, 2}(),
                   NullableArray{Bool, 2}(Array(Bool, 0, 0)))
 
-    # test conversion from arrays of nullables
-    array_of_nulls = Nullable{Int}[Nullable(1), Nullable(2), Nullable(3), Nullable()]
-    @test isa(NullableArray(array_of_nulls), NullableArray{Int,1})
-    @test isequal(NullableArray(array_of_nulls), NullableArray{Int,1}([1,2,3,4],[false,false,false,true]))
-    @test isa(NullableArray{Int64}(array_of_nulls), NullableArray{Int,1})
-    @test isequal(NullableArray{Int64}(array_of_nulls), NullableArray{Int,1}([1,2,3,4],[false,false,false,true]))
-    @test isa(NullableArray{Float64}(array_of_nulls), NullableArray{Float64,1})
-    @test isequal(NullableArray{Float64}(array_of_nulls), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],[false,false,false,true]))
-    @test isa(NullableArray{Int64,1}(array_of_nulls), NullableArray{Int,1})
-    @test isequal(NullableArray{Int64,1}(array_of_nulls), NullableArray{Int,1}([1,2,3,4],[false,false,false,true]))
-    @test isa(NullableArray{Float64,1}(array_of_nulls), NullableArray{Float64,1})
-    @test isequal(NullableArray{Float64,1}(array_of_nulls), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],[false,false,false,true]))
+    # test conversion from arrays, arrays of nullables and NullableArrays
+    miss1 = [false,false,false,false]
+    miss2 = [false,false,false,true]
+    for (a, miss) in zip(([1, 2, 3, 4],
+                          # 1:4, # Currently does not work on 0.4, cf. JuliaLang/julia#16265
+                          Nullable{Int}[Nullable(1), Nullable(2), Nullable(3), Nullable()],
+                          NullableArray(Nullable{Int}[Nullable(1), Nullable(2), Nullable(3), Nullable()])),
+                         (miss1, miss2, miss2))
+        @test isa(NullableArray(a), NullableArray{Int,1})
+        @test isequal(NullableArray(a), NullableArray{Int,1}([1,2,3,4],miss))
+        @test isa(NullableArray{Int64}(a), NullableArray{Int,1})
+        @test isequal(NullableArray{Int64}(a), NullableArray{Int,1}([1,2,3,4],miss))
+        @test isa(NullableArray{Float64}(a), NullableArray{Float64,1})
+        @test isequal(NullableArray{Float64}(a), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],miss))
+        @test isa(NullableArray{Int64,1}(a), NullableArray{Int,1})
+        @test isequal(NullableArray{Int64,1}(a), NullableArray{Int,1}([1,2,3,4],miss))
+        @test isa(NullableArray{Float64,1}(a), NullableArray{Float64,1})
+        @test isequal(NullableArray{Float64,1}(a), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],miss))
+
+        @test isa(convert(NullableArray, a), NullableArray{Int,1})
+        @test isequal(convert(NullableArray, a), NullableArray{Int,1}([1,2,3,4],miss))
+        @test isa(convert(NullableArray{Int64}, a), NullableArray{Int,1})
+        @test isequal(convert(NullableArray{Int64}, a), NullableArray{Int,1}([1,2,3,4],miss))
+        @test isa(convert(NullableArray{Float64}, a), NullableArray{Float64,1})
+        @test isequal(convert(NullableArray{Float64}, a), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],miss))
+        @test isa(convert(NullableArray{Int64,1}, a), NullableArray{Int,1})
+        @test isequal(convert(NullableArray{Int64,1}, a), NullableArray{Int,1}([1,2,3,4],miss))
+        @test isa(convert(NullableArray{Float64,1}, a), NullableArray{Float64,1})
+        @test isequal(convert(NullableArray{Float64,1}, a), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],miss))
+    end
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -272,14 +272,6 @@ module TestPrimitives
     Z = NullableArray([1 2; 3 4; 5 6; 7 8; 9 nothing], Int, Void)
     @test_throws NullException convert(Matrix, Z)
 
-    # Base.convert{S, T, N}(::Type{NullableArray{S, N}},
-    #                       A::NullableArray{T, N})
-    nd = rand(1:4)
-    _size = [ rand(1:20) for i in 1:nd ]
-    A = rand(Int, _size...)
-    @test isequal(convert(NullableArray{Float64, nd}, A),
-                  NullableArray(float(A)))
-
     # float(X::NullableArray)
     A = rand(Int, 20)
     M = rand(Bool, 20)


### PR DESCRIPTION
Instead of defining a NullableArray(a::AbstractArray) constructor, define
convert() methods and rely on the constructor fallback to convert(). This ensures
both ways are supported. Move all convert(NullableArray, ...) methods to
constructors.jl.

Also refactor tests to make them more systematic. Remove numbering of constructors,
since it's annoying when adding or removing one: refer to them using signatures instead.
