### PR TITLE
Fix ambiguity error in similar()

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -16,14 +16,9 @@ Allocate an uninitialized `NullableArray` of element type `T` and with
 size `dims`. If unspecified, `T` and `dims` default to the element type and size
 equal to that of `X`.
 """ ->
-function Base.similar{T<:Nullable}(X::NullableArray, ::Type{T}, dims::Dims)
-    NullableArray(eltype(T), dims)
+function Base.similar{T}(X::NullableArray, ::Type{T}, dims::Dims)
+    T<:Nullable ? NullableArray(eltype(T), dims) : NullableArray(T, dims)
 end
-
-# @doc """
-#
-# """ ->
-Base.similar(X::NullableArray, T, dims::Dims) = NullableArray(T, dims)
 
 @doc """
 `copy(X::NullableArray)`


### PR DESCRIPTION
New fallback definition for AbstractArray in Base is ambiguous when
T isn't specified as ::Type. Merge the two methods since type inference
also works in this simple case.
