### PR TITLE
Fix unshift! docstring and faster varargs

### DIFF
--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -55,7 +55,7 @@ function Base.unshift!(X::NullableVector, v::Nullable) # -> NullableVector{T}
 end
 
 @doc """
-`unshift!(X::NullableVector, v::Nullable)`
+`unshift!(X::NullableVector, v)`
 
 Insert a value `v` at the beginning of `X` and return `X`.
 """ ->
@@ -71,7 +71,10 @@ end
 Insert multiple values `vs` at the beginning of `X` and return `X`.
 """ ->
 function Base.unshift!(X::NullableVector, vs...)
-    return unshift!(unshift!(X, last(vs)), vs[1:endof(vs)-1]...)
+    for i in endof(vs):-1:1
+        unshift!(X, vs[i])
+    end
+    return X
 end
 
 @doc """

--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -185,9 +185,8 @@ collection to `append!`.
 function Base.append!(X::NullableVector, items::AbstractVector)
     old_length = length(X)
     nitems = length(items)
-    items_copy = convert(typeof(X), items)
     resize!(X, old_length + nitems)
-    X[old_length+1:end] = items_copy
+    copy!(X, length(X)-nitems+1, items, 1, nitems)
     return X
 end
 
@@ -203,10 +202,13 @@ collection to `prepend!`.
 function Base.prepend!(X::NullableVector, items::AbstractVector)
     old_length = length(X)
     nitems = length(items)
-    items_copy = convert(typeof(X), items)
     ccall(:jl_array_grow_beg, Void, (Any, UInt), X.values, nitems)
     ccall(:jl_array_grow_beg, Void, (Any, UInt), X.isnull, nitems)
-    X[1:nitems] = items_copy
+    if X === items
+        copy!(X, 1, items, nitems+1, nitems)
+    else
+        copy!(X, 1, items, 1, nitems)
+    end
     return X
 end
 

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -162,12 +162,12 @@ module TestNullableVector
 
     # Base.prepend!(X::NullableVector, items::AbstractVector)
 
-    XX = NullableArray([3:12...])
-    @test isequal(prepend!(XX, [1, 2]),
+    X = NullableArray([3:12...])
+    @test isequal(prepend!(X, [1, 2]),
                   NullableArray([1:12...]))
-    @test isequal(prepend!(XX, [Nullable(-1), Nullable(0)]),
+    @test isequal(prepend!(X, [Nullable(-1), Nullable(0)]),
                   NullableArray([-1:12...]))
-    @test isequal(prepend!(XX, [Nullable{Int64}(), Nullable(-2)]),
+    @test isequal(prepend!(X, [Nullable{Int64}(), Nullable(-2)]),
                   NullableArray([-3:12...], vcat(true, fill(false, 15))))
 
     #--- test Base.sizehint!

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -156,7 +156,7 @@ module TestNullableVector
     @test isequal(append!(X, [Nullable(13), Nullable(14)]),
                   NullableArray(2:14))
     @test isequal(append!(X, [Nullable(15), Nullable{Int}()]),
-                  NullableArray(Nullable{Int}[-2:12..., Nullable()]))
+                  NullableArray(Nullable{Int}[2:15..., Nullable()]))
 
     #--- test Base.prepend!
 

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -145,16 +145,16 @@ module TestNullableVector
     #--- test Base.deleteat!
 
     # Base.deleteat!(X::NullableArray, inds)
-    X = NullableArray([1:10...])
-    @test isequal(deleteat!(X, 1), NullableArray([2:10...]))
+    X = NullableArray(1:10)
+    @test isequal(deleteat!(X, 1), NullableArray(2:10))
 
     #--- test Base.append!
 
     # Base.append!(X::NullableVector, items::AbstractVector)
     @test isequal(append!(X, [11, 12]),
-                  NullableArray([2:12...]))
+                  NullableArray(2:12))
     @test isequal(append!(X, [Nullable(13), Nullable(14)]),
-                  NullableArray([2:14...]))
+                  NullableArray(2:14))
     @test isequal(append!(X, [Nullable(15), Nullable{Int}()]),
                   NullableArray(Nullable{Int}[-2:12..., Nullable()]))
 
@@ -162,11 +162,11 @@ module TestNullableVector
 
     # Base.prepend!(X::NullableVector, items::AbstractVector)
 
-    X = NullableArray([3:12...])
+    X = NullableArray(3:12)
     @test isequal(prepend!(X, [1, 2]),
-                  NullableArray([1:12...]))
+                  NullableArray(1:12))
     @test isequal(prepend!(X, [Nullable(-1), Nullable(0)]),
-                  NullableArray([-1:12...]))
+                  NullableArray(-1:12))
     @test isequal(prepend!(X, [Nullable{Int}(), Nullable(-2)]),
                   NullableArray(Nullable{Int}[Nullable(), -2:12...]))
 
@@ -178,13 +178,13 @@ module TestNullableVector
     #--- test padnull!
 
     # padnull!{T}(X::NullableVector{T}, front::Integer, back::Integer)
-    X = NullableArray([1:5...])
+    X = NullableArray(1:5)
     padnull!(X, 2, 3)
     @test length(X.values) == 10
     @test X.isnull == vcat(true, true, fill(false, 5), true, true, true)
 
     # padnull(X::NullableVector, front::Integer, back::Integer)
-    X = NullableArray([1:5...])
+    X = NullableArray(1:5)
     Y = padnull(X, 2, 3)
     @test length(Y.values) == 10
     @test Y.isnull == vcat(true, true, fill(false, 5), true, true, true)

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -21,6 +21,10 @@ module TestNullableVector
     push!(Z, Nullable(5))
     @test isequal(Z, NullableArray([5, 1, 5], [false, true, false]))
 
+    ZZ = NullableVector{Int}()
+    push!(ZZ, 5, Nullable(), Nullable(5))
+    @test isequal(ZZ, Z)
+
     #--- Base.pop!
 
     # Base.pop!(X::NullableArray)
@@ -42,7 +46,6 @@ module TestNullableVector
                   )
           )
 
-    # Base.unshift!(X::NullableVector, vs...)
     @test isequal(unshift!(Y, 1, Nullable(), Nullable(3)),
                   NullableArray([1, 2, 3, 1, 2, 3, 4, 5],
                                 [false, true, false, false,
@@ -152,8 +155,20 @@ module TestNullableVector
                   NullableArray([2:12...]))
     @test isequal(append!(X, [Nullable(13), Nullable(14)]),
                   NullableArray([2:14...]))
-    @test isequal(append!(X, [Nullable(15), Nullable()]),
+    @test isequal(append!(X, [Nullable(15), Nullable{Int64}()]),
                   NullableArray([2:16...], vcat(fill(false, 14), true)))
+
+    #--- test Base.prepend!
+
+    # Base.prepend!(X::NullableVector, items::AbstractVector)
+
+    XX = NullableArray([3:12...])
+    @test isequal(prepend!(XX, [1, 2]),
+                  NullableArray([1:12...]))
+    @test isequal(prepend!(XX, [Nullable(-1), Nullable(0)]),
+                  NullableArray([-1:12...]))
+    @test isequal(prepend!(XX, [Nullable{Int64}(), Nullable(-2)]),
+                  NullableArray([-3:12...], vcat(true, fill(false, 15))))
 
     #--- test Base.sizehint!
 

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -156,7 +156,7 @@ module TestNullableVector
     @test isequal(append!(X, [Nullable(13), Nullable(14)]),
                   NullableArray([2:14...]))
     @test isequal(append!(X, [Nullable(15), Nullable{Int64}()]),
-                  NullableArray([2:16...], vcat(fill(false, 14), true)))
+                  NullableArray(Nullable{Int}[-2:12..., Nullable()]))
 
     #--- test Base.prepend!
 
@@ -168,7 +168,7 @@ module TestNullableVector
     @test isequal(prepend!(X, [Nullable(-1), Nullable(0)]),
                   NullableArray([-1:12...]))
     @test isequal(prepend!(X, [Nullable{Int64}(), Nullable(-2)]),
-                  NullableArray([-3:12...], vcat(true, fill(false, 15))))
+                  NullableArray(Nullable{Int}[Nullable(), -2:12...]))
 
     #--- test Base.sizehint!
 

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -155,7 +155,7 @@ module TestNullableVector
                   NullableArray([2:12...]))
     @test isequal(append!(X, [Nullable(13), Nullable(14)]),
                   NullableArray([2:14...]))
-    @test isequal(append!(X, [Nullable(15), Nullable{Int64}()]),
+    @test isequal(append!(X, [Nullable(15), Nullable{Int}()]),
                   NullableArray(Nullable{Int}[-2:12..., Nullable()]))
 
     #--- test Base.prepend!
@@ -167,7 +167,7 @@ module TestNullableVector
                   NullableArray([1:12...]))
     @test isequal(prepend!(X, [Nullable(-1), Nullable(0)]),
                   NullableArray([-1:12...]))
-    @test isequal(prepend!(X, [Nullable{Int64}(), Nullable(-2)]),
+    @test isequal(prepend!(X, [Nullable{Int}(), Nullable(-2)]),
                   NullableArray(Nullable{Int}[Nullable(), -2:12...]))
 
     #--- test Base.sizehint!


### PR DESCRIPTION
Old version of `Base.unshift!(X::NullableVector, vs...)` was very slow for large number of varargs (especially on the first run for a given set of types of arguments) as Julia has to generate many intermediate function signatures. Here is an example:

```
x = NullableArray(Int64,0)
@time unshift!(x,(1:10000)...);
```

Now it works much faster than the old version.

Additionally small fix in unshift! method signature.
