### PR TITLE
Add a ref field to NullableArray

### DIFF
--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -21,15 +21,17 @@ reusing operations that only work on arrays without any null values.
 immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
     values::Array{T, N}
     isnull::Array{Bool, N}
+    # extra field for potentially holding a reference to a parent memory block
+    # (think mmapped file, for example) that `values` is actually derived from
+    parent::Vector{UInt8}
 
-    function NullableArray(d::AbstractArray{T, N}, m::Array{Bool, N})
+    function NullableArray(d::AbstractArray{T, N}, m::Array{Bool, N}, parent::Vector{UInt8}=Vector{UInt8}())
         if size(d) != size(m)
             msg = "values and missingness arrays must be the same size"
             throw(ArgumentError(msg))
         end
-        new(d, m)
+        new(d, m, parent)
     end
 end
-
 typealias NullableVector{T} NullableArray{T, 1}
 typealias NullableMatrix{T} NullableArray{T, 2}


### PR DESCRIPTION
Allows for easy interop in shared memory scenarios where a reference to a memory region is needed to prevent the `x.values` array from being invalidated. Implements #112.

I'd love to try this out, and finish another round of updates based on it for the DataStreams network (CSV, SQLite, ODBC, Feather).

We can even not tell anyone if desired, then I'm the only one who has breakage if we choose to deprecate at some point :)
