### PR TITLE
[WIP/RFC] functional operations on nullables as collections

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -30,4 +30,9 @@ include("reduce.jl")
 include("show.jl")
 include("subarray.jl")
 
+if VERSION ≥ v"0.5-"
+    include("functional.jl")
+    using .FunctionalNullableOperations
+end
+
 end

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -5,107 +5,75 @@ module FunctionalNullableOperations
 importall Base
 import Base: promote_op, LinearFast
 
-# conceptually, nullable types can be considered infinite-order tensor powers of
-# finite-dimensional vector spaces — we attempt to support most operations on
-# arrays except the linear algebra related ones; the infinite-dimensional nature
-# makes subtyping AbstractArray a little dangerous, which explains why
-# functionality is reimplemented instead of subtyping AbstractArray
-
-# size   – not implemented since an infinite-dimensional tuple would be strange
-# length – one or zero
-# endof  – same as length
-length(u::Nullable) = u.isnull ? 0 : 1
-endof(u::Nullable)  = length(u)
+length(x::Nullable) = x.isnull ? 0 : 1
+endof(x::Nullable)  = length(x)
 
 # indexing is either without index, or with 1 as index
 # generalized linear indexing is not supported
 # setindex! not supported because Nullable is immutable
 linearindexing{T}(::Nullable{T}) = LinearFast()
-function getindex(u::Nullable)
-    @boundscheck u.isnull && throw(NullException())
-    u.value
+function getindex(x::Nullable)
+    @boundscheck x.isnull && throw(NullException())
+    x.value
 end
-function getindex(u::Nullable, i::Integer)
-    @boundscheck u.isnull | (i ≠ one(i)) && throw(BoundsError(i, u))
-    u.value
+function getindex(x::Nullable, i::Integer)
+    @boundscheck (x.isnull | (i ≠ 1)) && throw(BoundsError(i, x))
+    x.value
 end
 
 # iteration protocol
-start(u::Nullable) = 1
-next(u::Nullable, i::Integer) = u.value, 0
-done(u::Nullable, i::Integer) = u.isnull || i == 0
+start(x::Nullable) = 1
+next(x::Nullable, i::Integer) = x.value, 0
+done(x::Nullable, i::Integer) = x.isnull | (i == 0)
 
-# next we have reimplementations of some higher-order functions
-filter{T}(p, u::Nullable{T}) = u.isnull ? u : p(u.value) ? u : Nullable{T}()
+# higher-order functions
+function filter{T}(p, x::Nullable{T})
+    if x.isnull
+        x
+    elseif p(x.value)
+        x
+    else
+        Nullable{T}()
+    end
+end
+map{T}(f, x::Nullable{T}) = x.isnull ? Nullable{Union{}}() : Nullable(f(x.value))
 
-# warning: not type-stable
-map{T}(f, u::Nullable{T}) = u.isnull ? Nullable{Union{}}() : Nullable(f(u.value))
-
-# multi-argument map doesn't broadcast, so not very useful, but no harm having
-# it...
-function map(f, us::Nullable...)
-    if all(isnull, us)
+function map(f, xs::Nullable...)
+    if all(isnull, xs)
         Nullable()
-    elseif !any(isnull, us)
-        Nullable(map(f, map(getindex, us)...))
+    elseif !any(isnull, xs)
+        Nullable(map(f, map(getindex, xs)...))
     else
         throw(DimensionMismatch("expected all null or all nonnull"))
     end
 end
 
-# foldr and foldl are quite useful to express "do something if not null, else"
-# these
+broadcast{T}(f, x::Nullable{T}) =
+    x.isnull ? Nullable{promote_op(f, T)}() : Nullable{promote_op(f, T)}(f(x.value))
 
-# being infinite-dimensional, nullables are generally incompatible with
-# broadcast with arrays — it is probably not worth supporting the rare case
-# where an array has length 0 or 1
+# FIXME: need fast implementation for 2/3? args
 
-# so we reimplement broadcast, which has the same semantics but very different
-# implementation. This implementation is in fact much simpler than that for
-# arrays. Length-1 (non-nulls) are flexible and can broadcast to length-0
-# (nulls), but the other way does not work. Numbers are zero-dimensional and can
-# broadcast to infinite-dimensional nullables, but the other direction is not
-# supported.
-
-# Base's broadcast has a very loose signature so we can easily make it more
-# specific. Broadcast on numbers is still not supported. FIXME: remove generated
-# functions where unnecessary
-
-# some specialized functions
-broadcast{T}(f, u::Nullable{T}) =
-    u.isnull ? Nullable{promote_op(f, T)}() : Nullable{promote_op(f, T)}(f(u.value))
-
-@generated function broadcast(f, u::Union{Nullable,Number}, v::Union{Nullable,Number})
-    checkfor(s) = :($s.isnull && return Nullable{result}())
-    lifted = [T <: Nullable ? T.parameters[1] : T for T in (u, v)]
-    checks = vcat(u <: Nullable ? [checkfor(:u)] : [],
-                  v <: Nullable ? [checkfor(:v)] : [])
-    quote
-        result = promote_op(f, $(lifted...))
-        $(checks...)
-        @inbounds return Nullable{result}(f(u[], v[]))
-    end
-end
-
-# functions with three arguments or more are a bit expensive to specialize...
-# FIXME: why the arbitrary cutoff? justify
-function broadcast(f, us::Union{Nullable, Number}...)
+# generic multi-argument implementation
+function broadcast(f, xs::Union{Nullable, Number}...)
     result = promote_op(f,
-        [T <: Nullable ? T.parameters[1] : T for T in map(typeof, us)]...)
-    for u in us
-        if isa(u, Nullable) && u.isnull
+        [T <: Nullable ? T.parameters[1] : T for T in map(typeof, xs)]...)
+    for x in xs
+        if isa(x, Nullable) && x.isnull
             return Nullable{result}()
         end
     end
-    @inbounds return Nullable{result}(f(map(getindex, us)...))
+    @inbounds return Nullable{result}(f(map(getindex, xs)...))
 end
 
-# FIXME: these operations are probably not all correct
+# FIXME: these operations may be incorrect
 # and definitely some of them are slow, needs specialization
 # also have to be careful to avoid ambiguities... needs testing
-for eop in :(.+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^).args
-    @eval $eop(u::Nullable, v::Union{Nullable, Number}) = broadcast($eop, u, v)
-    @eval $eop(u::Number, v::Nullable) = broadcast($eop, u, v)
+for (eop, op) in ((:.+, :+), (:.-, :-), (:.*, :*), (:./, :/), (:.\, :\),
+                  (:.//, ://), (:.==, :(==)), (:.<, :<), (:.!=, :!=),
+                  (:.<=, :<=), (:.÷, :÷), (:.%, :%), (:.<<, :<<), (:.>>, :>>),
+                  (:.^, :^))
+    @eval $eop(x::Nullable, y::Union{Nullable, Number}) = broadcast($op, x, y)
+    @eval $eop(x::Number, y::Nullable) = broadcast($op, x, y)
 end
 
 end # module

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -67,21 +67,6 @@ end
 # broadcast to infinite-dimensional nullables, but the other direction is not
 # supported.
 
-# there are two shapes we are concerned about: infinite-dimensional 1×1×...
-# and infinite-dimensional 0×0×...; we don't care about zero-dimensional because
-# in that case all arguments were numbers, and broadcasting over only numbers
-# isn't supported by base currently
-function nullable_broadcast_shape(us::Union{Nullable,Number}...)
-    for u in us
-        if isa(us, Nullable)
-            if u.isnull
-                return true
-            end
-        end
-    end
-    return false
-end
-
 # Base's broadcast has a very loose signature so we can easily make it more
 # specific. Broadcast on numbers is still not supported. FIXME: remove generated
 # functions where unnecessary

--- a/src/functional.jl
+++ b/src/functional.jl
@@ -1,0 +1,126 @@
+module FunctionalNullableOperations
+
+# extends Base with operations that treat nullables as collections
+
+importall Base
+import Base: promote_op, LinearFast
+
+# conceptually, nullable types can be considered infinite-order tensor powers of
+# finite-dimensional vector spaces — we attempt to support most operations on
+# arrays except the linear algebra related ones; the infinite-dimensional nature
+# makes subtyping AbstractArray a little dangerous, which explains why
+# functionality is reimplemented instead of subtyping AbstractArray
+
+# size   – not implemented since an infinite-dimensional tuple would be strange
+# length – one or zero
+# endof  – same as length
+length(u::Nullable) = u.isnull ? 0 : 1
+endof(u::Nullable)  = length(u)
+
+# indexing is either without index, or with 1 as index
+# generalized linear indexing is not supported
+# setindex! not supported because Nullable is immutable
+linearindexing{T}(::Nullable{T}) = LinearFast()
+function getindex(u::Nullable)
+    @boundscheck u.isnull && throw(NullException())
+    u.value
+end
+function getindex(u::Nullable, i::Integer)
+    @boundscheck u.isnull | (i ≠ one(i)) && throw(BoundsError(i, u))
+    u.value
+end
+
+# iteration protocol
+start(u::Nullable) = 1
+next(u::Nullable, i::Integer) = u.value, 0
+done(u::Nullable, i::Integer) = u.isnull || i == 0
+
+# next we have reimplementations of some higher-order functions
+filter{T}(p, u::Nullable{T}) = u.isnull ? u : p(u.value) ? u : Nullable{T}()
+
+# warning: not type-stable
+map{T}(f, u::Nullable{T}) = u.isnull ? Nullable{Union{}}() : Nullable(f(u.value))
+
+# multi-argument map doesn't broadcast, so not very useful, but no harm having
+# it...
+function map(f, us::Nullable...)
+    if all(isnull, us)
+        Nullable()
+    elseif !any(isnull, us)
+        Nullable(map(f, map(getindex, us)...))
+    else
+        throw(DimensionMismatch("expected all null or all nonnull"))
+    end
+end
+
+# foldr and foldl are quite useful to express "do something if not null, else"
+# these
+
+# being infinite-dimensional, nullables are generally incompatible with
+# broadcast with arrays — it is probably not worth supporting the rare case
+# where an array has length 0 or 1
+
+# so we reimplement broadcast, which has the same semantics but very different
+# implementation. This implementation is in fact much simpler than that for
+# arrays. Length-1 (non-nulls) are flexible and can broadcast to length-0
+# (nulls), but the other way does not work. Numbers are zero-dimensional and can
+# broadcast to infinite-dimensional nullables, but the other direction is not
+# supported.
+
+# there are two shapes we are concerned about: infinite-dimensional 1×1×...
+# and infinite-dimensional 0×0×...; we don't care about zero-dimensional because
+# in that case all arguments were numbers, and broadcasting over only numbers
+# isn't supported by base currently
+function nullable_broadcast_shape(us::Union{Nullable,Number}...)
+    for u in us
+        if isa(us, Nullable)
+            if u.isnull
+                return true
+            end
+        end
+    end
+    return false
+end
+
+# Base's broadcast has a very loose signature so we can easily make it more
+# specific. Broadcast on numbers is still not supported. FIXME: remove generated
+# functions where unnecessary
+
+# some specialized functions
+broadcast{T}(f, u::Nullable{T}) =
+    u.isnull ? Nullable{promote_op(f, T)}() : Nullable{promote_op(f, T)}(f(u.value))
+
+@generated function broadcast(f, u::Union{Nullable,Number}, v::Union{Nullable,Number})
+    checkfor(s) = :($s.isnull && return Nullable{result}())
+    lifted = [T <: Nullable ? T.parameters[1] : T for T in (u, v)]
+    checks = vcat(u <: Nullable ? [checkfor(:u)] : [],
+                  v <: Nullable ? [checkfor(:v)] : [])
+    quote
+        result = promote_op(f, $(lifted...))
+        $(checks...)
+        @inbounds return Nullable{result}(f(u[], v[]))
+    end
+end
+
+# functions with three arguments or more are a bit expensive to specialize...
+# FIXME: why the arbitrary cutoff? justify
+function broadcast(f, us::Union{Nullable, Number}...)
+    result = promote_op(f,
+        [T <: Nullable ? T.parameters[1] : T for T in map(typeof, us)]...)
+    for u in us
+        if isa(u, Nullable) && u.isnull
+            return Nullable{result}()
+        end
+    end
+    @inbounds return Nullable{result}(f(map(getindex, us)...))
+end
+
+# FIXME: these operations are probably not all correct
+# and definitely some of them are slow, needs specialization
+# also have to be careful to avoid ambiguities... needs testing
+for eop in :(.+, .-, .*, ./, .\, .//, .==, .<, .!=, .<=, .÷, .%, .<<, .>>, .^).args
+    @eval $eop(u::Nullable, v::Union{Nullable, Number}) = broadcast($eop, u, v)
+    @eval $eop(u::Number, v::Nullable) = broadcast($eop, u, v)
+end
+
+end # module

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -4,11 +4,11 @@ module TestFunctional
 # and a "is a nullable with value egal to k"
 
 # these functions are curried for readability
-isnull_typed(u::Nullable, T::Type) = typeof(u).parameters[1] == T && isnull(u)
-isnull_typed(t::Type) = u -> isnull_typed(u, t)
+isnull_typed(x::Nullable, T::Type) = typeof(x).parameters[1] == T && isnull(x)
+isnull_typed(t::Type) = x -> isnull_typed(x, t)
 
-isnullableof(u::Nullable, x) = !isnull(u) && u.value === x
-isnullableof(x) = u -> isnullableof(u, x)
+isnullableof(y::Nullable, x) = !isnull(y) && y.value === x
+isnullableof(x) = y -> isnullableof(y, x)
 
 using Base.Test
 
@@ -17,21 +17,27 @@ using Base.Test
 @test_throws NullException Nullable{Int}()[]
 @test Nullable(0)[] == 0
 
+@test_throws BoundsError Nullable()[-1]
+@test_throws BoundsError Nullable()[0]
 @test_throws BoundsError Nullable()[1]
+@test_throws BoundsError Nullable()[2]
+@test_throws BoundsError Nullable()[big(2)^64 + 1]
+@test_throws BoundsError Nullable(0)[-1]
 @test_throws BoundsError Nullable(0)[0]
 @test_throws BoundsError Nullable(0)[2]
 @test Nullable(0)[1] == 0
 
 # collect
-@test collect(Nullable()) == Union{}[]
-@test collect(Nullable{Int}()) == Int[]
-@test collect(Nullable(85)) == Int[85]
-@test collect(Nullable(1.0)) == Float64[1.0]
+@test isempty(collect(Nullable())) && eltype(collect(Nullable())) == Union{}
+@test isempty(collect(Nullable{Int}())) && eltype(collect(Nullable{Int}())) == Int
+@test collect(Nullable(85)) == [85] && eltype(collect(Nullable(85))) == Int
+@test collect(Nullable(1.0)) == [1.0] && eltype(collect(Nullable(1.0))) == Float64
 
-# length
+# length & endof
 @test length(Nullable()) == 0
 @test length(Nullable{Int}()) == 0
 @test length(Nullable(1.0)) == 1
+@test endof(Nullable()) == 0
 @test endof(Nullable(85)) == 1
 
 # filter
@@ -56,15 +62,10 @@ sqr(x) = x^2
 
 # example: square if value exists, -1 if value is null
 # with foldl/foldr/reduce
-for fn in (foldl, foldr, reduce)
-    @test foldl((_, x) -> x^2, -1, Nullable())   == -1
-    @test foldl((_, x) -> x^2, -1, Nullable(10)) == 100
-end
-
-# with broadcast and get (map does not work because of get limitations...)
-# perhaps the get limitations should be fixed
-@test get(sqr.(Nullable{Int}()), -1) == -1
-@test get(sqr.(Nullable(10)), -1)    == 100
+@test foldl((_, x) -> x^2, -1, Nullable())   == -1
+@test foldl((_, x) -> x^2, -1, Nullable(10)) == 100
+@test foldr((x, _) -> x^2, -1, Nullable())   == -1
+@test foldr((x, _) -> x^2, -1, Nullable(10)) == 100
 
 # broadcast and elementwise
 @test sin.(Nullable(0.0))             |> isnullableof(0.0)
@@ -75,19 +76,20 @@ end
 @test Nullable(8) .+ Nullable{Int}()  |> isnull_typed(Int)
 @test Nullable{Int}() .- Nullable(10) |> isnull_typed(Int)
 
-@test log.(10, Nullable(1.0))         |> isnullableof(0.0)
-@test log.(10, Nullable{Float64}())   |> isnull_typed(Float64)
+@test log.(10, Nullable(1.0))                 |> isnullableof(0.0)
+@test log.(10, Nullable{Float64}())           |> isnull_typed(Float64)
+@test log.(Nullable(10), Nullable(1.0))       |> isnullableof(0.0)
+@test log.(Nullable(10), Nullable{Float64}()) |> isnull_typed(Float64)
 
 @test Nullable(2) .^ Nullable(4)      |> isnullableof(16)
 @test Nullable(2) .^ Nullable{Int}()  |> isnull_typed(Int)
 
-# big broadcast (slow)
+# multi-arg broadcast
 @test Nullable(1) .+ Nullable(1) .+ Nullable(1) .+ Nullable(1) .+ Nullable(1) .+
     Nullable(1) |> isnullableof(6)
 @test Nullable(1) .+ Nullable(1) .+ Nullable(1) .+ Nullable{Int}() .+
     Nullable(1) .+ Nullable(1) |> isnull_typed(Int)
 
-# very slow but it should work
 us = map(Nullable, 1:20)
 @test broadcast(max, us...)                  |> isnullableof(20)
 @test broadcast(max, us..., Nullable{Int}()) |> isnull_typed(Int)
@@ -97,12 +99,12 @@ s = 0
 for x in Nullable(10)
     s += x
 end
-@test s == 10
+@test s === 10
 
 s = 0
 for x in Nullable{Int}()
     s += x
 end
-@test s == 0
+@test s === 0
 
 end

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -1,0 +1,108 @@
+module TestFunctional
+
+# nullable equality is a little strange... we need a "is a null with type T"
+# and a "is a nullable with value egal to k"
+
+# these functions are curried for readability
+isnull_typed(u::Nullable, T::Type) = typeof(u).parameters[1] == T && isnull(u)
+isnull_typed(t::Type) = u -> isnull_typed(u, t)
+
+isnullableof(u::Nullable, x) = !isnull(u) && u.value === x
+isnullableof(x) = u -> isnullableof(u, x)
+
+using Base.Test
+
+# getindex
+@test_throws NullException Nullable()[]
+@test_throws NullException Nullable{Int}()[]
+@test Nullable(0)[] == 0
+
+@test_throws BoundsError Nullable()[1]
+@test_throws BoundsError Nullable(0)[0]
+@test_throws BoundsError Nullable(0)[2]
+@test Nullable(0)[1] == 0
+
+# collect
+@test collect(Nullable()) == Union{}[]
+@test collect(Nullable{Int}()) == Int[]
+@test collect(Nullable(85)) == Int[85]
+@test collect(Nullable(1.0)) == Float64[1.0]
+
+# length
+@test length(Nullable()) == 0
+@test length(Nullable{Int}()) == 0
+@test length(Nullable(1.0)) == 1
+@test endof(Nullable(85)) == 1
+
+# filter
+for p in (_ -> true, _ -> false)
+    @test filter(p, Nullable())      |> isnull_typed(Union{})
+    @test filter(p, Nullable{Int}()) |> isnull_typed(Int)
+end
+@test filter(_ -> true, Nullable(85))  |> isnullableof(85)
+@test filter(_ -> false, Nullable(85)) |> isnull_typed(Int)
+@test filter(x -> x > 0, Nullable(85)) |> isnullableof(85)
+@test filter(x -> x < 0, Nullable(85)) |> isnull_typed(Int)
+
+# map
+sqr(x) = x^2
+@test map(sqr, Nullable())      |> isnull_typed(Union{})
+@test map(sqr, Nullable{Int}()) |> isnull_typed(Union{})  # type-unstable (!)
+@test map(sqr, Nullable(2))     |> isnullableof(4)
+
+@test map(+, Nullable(1), Nullable(2), Nullable(3)) |> isnullableof(6)
+@test map(+, Nullable(), Nullable(), Nullable())    |> isnull_typed(Union{})
+@test map(+, Nullable{Int}(), Nullable{Int}())      |> isnull_typed(Union{})
+
+# example: square if value exists, -1 if value is null
+# with foldl/foldr/reduce
+for fn in (foldl, foldr, reduce)
+    @test foldl((_, x) -> x^2, -1, Nullable())   == -1
+    @test foldl((_, x) -> x^2, -1, Nullable(10)) == 100
+end
+
+# with broadcast and get (map does not work because of get limitations...)
+# perhaps the get limitations should be fixed
+@test get(sqr.(Nullable{Int}()), -1) == -1
+@test get(sqr.(Nullable(10)), -1)    == 100
+
+# broadcast and elementwise
+@test sin.(Nullable(0.0))             |> isnullableof(0.0)
+@test sin.(Nullable{Float64}())       |> isnull_typed(Float64)
+
+@test Nullable(8) .+ Nullable(10)     |> isnullableof(18)
+@test Nullable(8) .- Nullable(10)     |> isnullableof(-2)
+@test Nullable(8) .+ Nullable{Int}()  |> isnull_typed(Int)
+@test Nullable{Int}() .- Nullable(10) |> isnull_typed(Int)
+
+@test log.(10, Nullable(1.0))         |> isnullableof(0.0)
+@test log.(10, Nullable{Float64}())   |> isnull_typed(Float64)
+
+@test Nullable(2) .^ Nullable(4)      |> isnullableof(16)
+@test Nullable(2) .^ Nullable{Int}()  |> isnull_typed(Int)
+
+# big broadcast (slow)
+@test Nullable(1) .+ Nullable(1) .+ Nullable(1) .+ Nullable(1) .+ Nullable(1) .+
+    Nullable(1) |> isnullableof(6)
+@test Nullable(1) .+ Nullable(1) .+ Nullable(1) .+ Nullable{Int}() .+
+    Nullable(1) .+ Nullable(1) |> isnull_typed(Int)
+
+# very slow but it should work
+us = map(Nullable, 1:20)
+@test broadcast(max, us...)                  |> isnullableof(20)
+@test broadcast(max, us..., Nullable{Int}()) |> isnull_typed(Int)
+
+# imperative style
+s = 0
+for x in Nullable(10)
+    s += x
+end
+@test s == 10
+
+s = 0
+for x in Nullable{Int}()
+    s += x
+end
+@test s == 0
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ fatalerrors = length(ARGS) > 0 && ARGS[1] == "-f"
 quiet = length(ARGS) > 0 && ARGS[1] == "-q"
 anyerrors = false
 
-my_tests = [
+my_tests = [] #= [
     "typedefs.jl",
     "constructors.jl",
     "primitives.jl",
@@ -17,7 +17,11 @@ my_tests = [
     "operators.jl",
     "subarray.jl",
     "show.jl",
-]
+] =#
+
+if VERSION ≥ v"0.5-"
+    push!(my_tests, "functional.jl")
+end
 
 println("Running tests:")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ fatalerrors = length(ARGS) > 0 && ARGS[1] == "-f"
 quiet = length(ARGS) > 0 && ARGS[1] == "-q"
 anyerrors = false
 
-my_tests = [] #= [
+my_tests = [
     "typedefs.jl",
     "constructors.jl",
     "primitives.jl",
@@ -17,7 +17,7 @@ my_tests = [] #= [
     "operators.jl",
     "subarray.jl",
     "show.jl",
-] =#
+]
 
 if VERSION ≥ v"0.5-"
     push!(my_tests, "functional.jl")


### PR DESCRIPTION
This implements Scala-style `map` and `filter`. I did not implement Scala's fold semantics, because I consider that to be a mistake, since it is inconsistent with the regular `foldr` and `foldl`, which I did keep. Since `map` is not type-stable, I also implemented `broadcast` as a type-stable `map`. `broadcast` also preserves the broadcasting capability of the version for arrays.

I also implemented x[] and x[1] to replace `get(x)`. Finally, I added in the iteration interface, which allows imperative-style for loops as well as functional-style higher order functions.

John presented several options for propagation in this [old mailing list post](https://groups.google.com/forum/#!msg/julia-dev/WD7-vQeweJE/yGBFU2E2b2cJ), which I quote:

```
As I see it, progagation can work in a couple of ways:

(1) Always off: you can't propagate nullability without explicitly constructing a Nullable object.
(2) Opt-in at the call-site: you can propagate nullability by using something like map(f, Nullable).
(3) Opt-in near the call-site: you can propagate nullability within a block of code using something like @propagate begin x = Nullable(1) + Nullable(2); sin(x) end
(4) Opt-in at the definition site: you can propagate nullability by annotating a function as propagating in the same way that we annotate functions as vectorizable.
(5) Always on: you can't prevent propagation without explicitly checking for nullability before calling any function.
```

The implementation of `broadcast` here doubles as an implementation of (2). This is simply a nice result of the algebraic properties of broadcasting. With new broadcast syntactic sugar, (2) is no longer very verbose. I think alternative syntaxes like ? are hence no longer required.

---

Notes: (optional, sorry for the long PR)
- I avoided implementing the Haskell-style monadic functions, because I don't think Julia has any monads and so that would be a big departure. The Scala-style functions feel more typical in a Julia environment.
- I haven't optimized for performance yet. Obviously some functions will need to be specialized. But since 0.5 allows specialization on functions, I am sure that this syntax can be made as fast as any manual lowering.
- Over the course of this PR I discovered some further nasty things with nullable, such as how `get(Nullable(), 1)` doesn't work (it expects a `Union{}` second argument?!) and how equality comparison is a bit broken (try `Nullable() == Nullable()`). I am new to Nullables so please excuse if there is a reason for this behaviour, but I found it heavily unintuitive.
- This is only turned on on v0.5- right now. It can probably be extended to 0.4 (I don't see why not) but performance will be terrible and the shorthand `.` broadcast syntax will not be available.
- I would prefer to deprecate `get(u)` in favour of `u[]`. The former syntax seems strange to me, as all other uses of `get` in Julia include a default value. I don't know if this is a popular viewpoint; my background in nullables comes more from Lisp (where `(cons x nil)` can be used as `Nullable(x)`) and Scala than from numerical computing languages.
- Mathematically, I'm treating nullables akin to infinite-dimensional square arrays here. (More precisely, a Nullable type is an union of infinite-order tensor power [defining "infinite" here as "arbitrarily large and finite", since actual infinite-order tensor powers probably behave more strangely] of finite-dimensional vector spaces, of course disallowing infinite objects. The reason for this long-winded analogy is that it's basically a `SquareArray{T, ∞}`, which provides a baseline for what should and shouldn't work.) This is perfectly consistent algebraically but the algebra is unimportant. It's only a guide for what kind of functionality should be implemented.
- While the mathematics makes sense to me, I couldn't find any papers on treating Option values as infinite-order tensor powers of finite-dimensional vector spaces, and I wouldn't be surprised if this was not a description in use at all. So if this turns out to be absolutely incoherent, then let's abandon the analogy. I just thought that it is quite nice for explaining the parallel for `broadcast` and for indexing, as identical operations.
