### PR TITLE
Improve operators

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,121 +1,128 @@
-import Compat: @functorize
+## Lifted operators
 
-@noinline throw_error() = error()
+importall Base.Operators
+import Base: promote_op, abs, abs2, sqrt, cbrt, scalarmin, scalarmax
+using Compat: @functorize
 
-for f in (
-    :(@compat Base.:+),
-    :(@compat Base.:-),
-    :(@compat Base.:!),
-    :(@compat Base.:~),
-)
+# Methods adapted from Base Julia 0.5
+if VERSION <= v"0.5.0-dev"
+    promote_op(::Any, T) = T
+    promote_op{T}(::Type{T}, ::Any) = T
+
+    promote_op{R<:Number}(op, ::Type{R}) = typeof(op(one(R)))
+    promote_op{R<:Number,S<:Number}(op, ::Type{R}, ::Type{S}) = typeof(op(one(R), one(S)))
+end
+
+"""
+    null_safe_op(f::Any, ::Type)::Bool
+    null_safe_op(f::Any, ::Type, ::Type)::Bool
+
+Returns whether an operation `f` can safely be applied to any value of the passed type(s).
+Returns `false` by default.
+
+Custom types should implement methods for some or all operations `f` when applicable:
+returning `true` means that the operation may be called on any bit pattern without
+throwing an error (though returning invalid or nonsensical results is not a problem).
+In particular, this means that the operation can be applied on the whole domain of the
+type *and on uninitialized objects*. As a general rule, these proporties are only true for
+safe operations on `isbits` types.
+
+Types declared as safe can benefit from higher performance for operations on nullable: by
+always computing the result even for null values, a branch is avoided, which helps
+vectorization.
+"""
+null_safe_op(f::Any, ::Type) = false
+null_safe_op(f::Any, ::Type, ::Type) = false
+
+typealias SafeSignedInts Union{Int128,Int16,Int32,Int64,Int8}
+typealias SafeUnsignedInts Union{Bool,UInt128,UInt16,UInt32,UInt64,UInt8}
+typealias SafeInts  Union{SafeSignedInts,SafeUnsignedInts}
+typealias SafeFloats Union{Float16,Float32,Float64}
+
+# Float types appear in both since they promote to themselves,
+# and therefore can't fail due to conversion of negative numbers
+typealias SafeSigned Union{SafeSignedInts,SafeFloats}
+typealias SafeUnsigned Union{SafeUnsignedInts,SafeFloats}
+typealias SafeTypes Union{SafeInts,SafeFloats}
+
+# Unary operators
+
+# Note this list does not include sqrt since it can raise an error,
+# nor cbrt (for which there is no functor on Julia 0.4)
+for op in (:+, :-, :abs, :abs2)
     @eval begin
-        @inline function $(f){S}(x::Nullable{S})
-            if isbits(S)
-                Nullable($(f)(x.value), x.isnull)
+        null_safe_op{T<:SafeTypes}(::typeof(@functorize($op)), ::Type{T}) = true
+    end
+end
+
+# No functors for these methods on 0.4: use the slow path
+if VERSION >= v"0.5.0-dev"
+    null_safe_op{T<:SafeInts}(::typeof(~), ::Type{T}) = true
+    null_safe_op{T<:SafeTypes}(::typeof(cbrt), ::Type{T}) = true
+    null_safe_op(::typeof(!), ::Type{Bool}) = true
+end
+
+for op in (:+, :-, :!, :~, :abs, :abs2, :sqrt, :cbrt)
+    @eval begin
+        @inline function $op{S}(x::Nullable{S})
+            R = promote_op($op, S)
+            if null_safe_op(@functorize($op), S)
+                Nullable{R}($op(x.value), x.isnull)
             else
-                throw_error()
+                x.isnull ? Nullable{R}() :
+                           Nullable{R}($op(x.value))
             end
         end
     end
 end
 
-# Implement the binary operators: +, -, *, /, %, &, |, ^, <<, and >>
-for f in (
-    :(@compat Base.:+),
-    :(@compat Base.:-),
-    :(@compat Base.:*),
-    :(@compat Base.:/),
-    :(@compat Base.:%),
-    :(@compat Base.:&),
-    :(@compat Base.:|),
-    :(@compat Base.:^),
-    :(@compat Base.:<<),
-    :(@compat Base.:>>),
-)
-    @eval begin
-        @inline function $(f){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
-            if isbits(S1) & isbits(S2)
-                Nullable($(f)(x.value, y.value), x.isnull | y.isnull)
-            else
-                throw_error()
-            end
+# Binary operators
+
+# Note this list does not include ^, ÷ and %
+# Operations between signed and unsigned types are not safe: promotion to unsigned
+# gives an InexactError for negative numbers
+if VERSION >= v"0.5.0-dev"
+    for op in (:+, :-, :*, :/, :&, :|, :<<, :>>, :(>>>),
+               :(==), :<, :>, :<=, :>=,
+               :scalarmin, :scalarmax)
+        @eval begin
+            # to fix ambiguities
+            null_safe_op{S<:SafeFloats,
+                         T<:SafeFloats}(::typeof($op), ::Type{S}, ::Type{T}) = true
+            null_safe_op{S<:SafeSigned,
+                         T<:SafeSigned}(::typeof($op), ::Type{S}, ::Type{T}) = true
+            null_safe_op{S<:SafeUnsigned,
+                         T<:SafeUnsigned}(::typeof($op), ::Type{S}, ::Type{T}) = true
+        end
+    end
+else # No functors for all methods on 0.4: use the slow path for missing ones
+    for op in (:+, :-, :*, :/, :&, :|,
+               :<, :>,
+               :scalarmin, :scalarmax)
+        @eval begin
+            # to fix ambiguities
+            null_safe_op{S<:SafeFloats,
+                         T<:SafeFloats}(::typeof(@functorize($op)), ::Type{S}, ::Type{T}) = true
+            null_safe_op{S<:SafeSigned,
+                         T<:SafeSigned}(::typeof(@functorize($op)), ::Type{S}, ::Type{T}) = true
+            null_safe_op{S<:SafeUnsigned,
+                         T<:SafeUnsigned}(::typeof(@functorize($op)), ::Type{S}, ::Type{T}) = true
         end
     end
 end
 
-# Implement the binary operators: == and !=
-for f in (
-    :(@compat Base.:(==)),
-    :(@compat Base.:!=),
-)
+for op in (:+, :-, :*, :/, :%, :÷, :&, :|, :^, :<<, :>>, :(>>>),
+           :(==), :<, :>, :<=, :>=,
+           :scalarmin, :scalarmax)
     @eval begin
-        function $(f){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
-            if isbits(S1) & isbits(S2)
-                Nullable{Bool}($(f)(x.value, y.value), x.isnull | y.isnull)
+        @inline function $op{S,T}(x::Nullable{S}, y::Nullable{T})
+            R = promote_op(@functorize($op), S, T)
+            if null_safe_op(@functorize($op), S, T)
+                Nullable{R}($op(x.value, y.value), x.isnull | y.isnull)
             else
-                error()
+                (x.isnull | y.isnull) ? Nullable{R}() :
+                                        Nullable{R}($op(x.value, y.value))
             end
         end
-    end
-end
-
-# Implement the binary operators: <, >, <=, and >=
-for f in (
-    :(@compat Base.:<),
-    :(@compat Base.:>),
-    :(@compat Base.:<=),
-    :(@compat Base.:>=),
-)
-    @eval begin
-        function $(f){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
-            if isbits(S1) & isbits(S2)
-                Nullable{Bool}($(f)(x.value, y.value), x.isnull | y.isnull)
-            else
-                error()
-            end
-        end
-    end
-end
-
-# Miscellaneous lifted operators
-
-function Base.abs{T}(x::Nullable{T})
-    if isbits(T)
-        return Nullable(abs(x.value), x.isnull)
-    else
-        error()
-    end
-end
-
-function Base.abs2{T}(x::Nullable{T})
-    if isbits(T)
-        return Nullable(abs2(x.value), x.isnull)
-    else
-        error()
-    end
-end
-
-function Base.sqrt{T}(x::Nullable{T})
-    if isbits(T)
-        return Nullable(sqrt(x.value), x.isnull)
-    else
-        error()
-    end
-end
-
-## Lifted functors
-
-@compat function (::typeof(@functorize(scalarmin))){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
-    if isbits(S1) & isbits(S2)
-        return Nullable(Base.scalarmin(x.value, y.value), x.isnull | y.isnull)
-    else
-        error()
-    end
-end
-@compat function (::typeof(@functorize(scalarmax))){S1, S2}(x::Nullable{S1}, y::Nullable{S2})
-    if isbits(S1) & isbits(S2)
-        return Nullable(Base.scalarmax(x.value, y.value), x.isnull | y.isnull)
-    else
-        error()
     end
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -73,6 +73,7 @@ for op in (:+, :-, :!, :~, :abs, :abs2, :sqrt, :cbrt)
                            Nullable{R}($op(x.value))
             end
         end
+        $op(x::Nullable{Union{}}) = Nullable()
     end
 end
 
@@ -124,5 +125,8 @@ for op in (:+, :-, :*, :/, :%, :÷, :&, :|, :^, :<<, :>>, :(>>>),
                                         Nullable{R}($op(x.value, y.value))
             end
         end
+        $op(x::Nullable{Union{}}, y::Nullable{Union{}}) = Nullable()
+        $op{S}(x::Nullable{Union{}}, y::Nullable{S}) = Nullable{S}()
+        $op{S}(x::Nullable{S}, y::Nullable{Union{}}) = Nullable{S}()
     end
 end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -99,6 +99,9 @@ module TestOperators
             @test isa(x, Nullable{R}) && isnull(x)
             x = op(Nullable{R}())
             @test isa(x, Nullable{R}) && isnull(x)
+
+            x = op(Nullable())
+            @test isa(x, Nullable{Union{}}) && isnull(x)
         end
 
         # unsafe unary operators
@@ -119,6 +122,9 @@ module TestOperators
         @test isa(x, Nullable{R}) && isnull(x)
         x = sqrt(Nullable{R}())
         @test isa(x, Nullable{R}) && isnull(x)
+
+        x = sqrt(Nullable())
+        @test isa(x, Nullable{Union{}}) && isnull(x)
 
         for u in (u0, u1, u2), v in (v0, v1, v2)
             # safe binary operators
@@ -143,6 +149,13 @@ module TestOperators
                 @test isa(x, Nullable{R}) && isnull(x)
                 x = op(Nullable(u, true), Nullable(v))
                 @test isa(x, Nullable{R}) && isnull(x)
+
+                x = op(Nullable(u, true), Nullable())
+                @test isa(x, Nullable{S}) && isnull(x)
+                x = op(Nullable(), Nullable(u, true))
+                @test isa(x, Nullable{S}) && isnull(x)
+                x = op(Nullable(), Nullable())
+                @test isa(x, Nullable{Union{}}) && isnull(x)
             end
 
             # unsafe binary operators
@@ -159,6 +172,13 @@ module TestOperators
             x = Nullable(u, true)^Nullable(-abs(v), false)
             @test isnull(x) && eltype(x) === R
 
+            x = Nullable(u, true)^Nullable()
+            @test isa(x, Nullable{S}) && isnull(x)
+            x = Nullable()^Nullable(u, true)
+            @test isa(x, Nullable{S}) && isnull(x)
+            x = Nullable()^Nullable()
+            @test isa(x, Nullable{Union{}}) && isnull(x)
+
             # ÷ and %
             for op in (÷, %)
                 if S <: Integer && T <: Integer && v == 0
@@ -173,6 +193,13 @@ module TestOperators
                 @test isnull(x) && eltype(x) === R
                 x = op(Nullable(u, true), Nullable(v, false))
                 @test isnull(x) && eltype(x) === R
+
+                x = op(Nullable(u, true), Nullable())
+                @test isa(x, Nullable{S}) && isnull(x)
+                x = op(Nullable(), Nullable(u, true))
+                @test isa(x, Nullable{S}) && isnull(x)
+                x = op(Nullable(), Nullable())
+                @test isa(x, Nullable{Union{}}) && isnull(x)
             end
         end
     end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -17,59 +17,163 @@ module TestOperators
     X = NullableArray(B)
     Y = NullableArray(B, M)
 
-    # 1-ary ops
-    for op in (
-        +,
-        -,
-        # ~,
-        sqrt,
-    )
-        v = rand(1:1_000)
-        x = op(Nullable(v))
-        @test_approx_eq x.value op(v)
-        @test !x.isnull
-        @test_throws ErrorException op(Nullable(rand(Int, 1)))
+    srand(1)
+    ensure_neg(x::Unsigned) = -convert(Signed, x)
+    ensure_neg(x::Any) = -abs(x)
+
+    # check for fast path (null-safe combinations of operators and types)
+    if VERSION >= v"0.5.0-dev" # Some functors are missing on 0.4.0, don't check fast path
+        for S in NullableArrays.SafeTypes.types,
+            T in NullableArrays.SafeTypes.types
+            # mixing signed and unsigned types is unsafe (slow path tested below)
+            ((S <: Signed) $ (T <: Signed)) && continue
+
+            u0 = zero(S)
+            u1 = one(S)
+            u2 = rand(S)
+
+            v0 = zero(T)
+            v1 = one(T)
+            v2 = rand(T)
+
+            # safe unary operators
+            for op in (+, -, ~, abs, abs2, cbrt)
+                S <: AbstractFloat && op == (~) && continue
+
+                @test op(Nullable(u0)) === Nullable(op(u0))
+                @test op(Nullable(u1)) === Nullable(op(u1))
+                @test op(Nullable(u2)) === Nullable(op(u2))
+                @test op(Nullable(u0, true)) === Nullable(op(u0), true)
+            end
+
+            for u in (u0, u1, u2), v in (v0, v1, v2)
+                # safe binary operators: === checks that the fast-path was taken (no branch)
+                for op in (+, -, *, /, &, |, >>, <<, >>>,
+                           <, >, <=, >=,
+                           Base.scalarmin, Base.scalarmax)
+                    (T <: AbstractFloat || S <: AbstractFloat) && op in (&, |, >>, <<, >>>) && continue
+
+                    @test op(Nullable(u), Nullable(v)) === Nullable(op(u, v))
+                    @test op(Nullable(u, true), Nullable(v, true)) === Nullable(op(u, v), true)
+                    @test op(Nullable(u), Nullable(v, true)) === Nullable(op(u, v), true)
+                    @test op(Nullable(u, true), Nullable(v)) === Nullable(op(u, v), true)
+                end
+            end
+        end
+
+        @test !Nullable(true) === Nullable(false)
+        @test !Nullable(false) === Nullable(true)
+        @test !(Nullable(true, true)) === Nullable(false, true)
+        @test !(Nullable(false, true)) === Nullable(true, true)
     end
 
-    # 2-ary arithmetic/comparison ops
-    for op in (
-        +,
-        -,
-        *,
-        /,
-        %,
-        ^,
-        >,
-        <,
-    )
-        v, w = rand(1:10), rand(1:10)
-        x = op(Nullable(v), Nullable(w))
-        @test_approx_eq x.value op(v, w)
-        @test !x.isnull
-        @test_throws ErrorException op(Nullable(rand(1)), Nullable(rand(1)))
-    end
+    # test all types and operators (including null-unsafe ones)
+    for S in Union{NullableArrays.SafeTypes, BigInt, BigFloat}.types,
+        T in Union{NullableArrays.SafeTypes, BigInt, BigFloat}.types
+        u0 = zero(S)
+        u1 = one(S)
+        u2 = S <: Union{BigInt, BigFloat} ? S(rand(Int128)) : rand(S)
 
-    # 2-ary logical ops
-    for op in (
-        &,
-        |,
-    )
-        v, w = rand(Bool), rand(Bool)
-        x = op(Nullable(v), Nullable(w))
-        @test_approx_eq x.value op(v, w)
-        @test !x.isnull
-        @test_throws ErrorException op(Nullable(rand(Bool, 1)), Nullable(rand(Bool, 1)))
-    end
+        v0 = zero(T)
+        v1 = one(T)
+        v2 = T <: Union{BigInt, BigFloat} ? T(rand(Int128)) : rand(T)
 
-    # 2-ary bitwise ops
-    for op in (
-        <<,
-        >>,
-    )
-        v, w = rand(1:10), rand(1:10)
-        x = op(Nullable(v), Nullable(w))
-        @test_approx_eq x.value op(v, w)
-        @test !x.isnull
-        @test_throws ErrorException op(Nullable(rand(Int, 1)), Nullable(rand(Int, 1)))
+        abs(v2) > 5 && (v2 = T(5)) # Work around JuliaLang/julia#16989
+
+        # safe unary operators
+        for op in (+, -, ~, abs, abs2, cbrt)
+            T <: AbstractFloat && op == (~) && continue
+
+            R = Base.promote_op(op, T)
+            x = op(Nullable(v0))
+            @test isa(x, Nullable{R}) && isequal(x, Nullable(op(v0)))
+            x = op(Nullable(v1))
+            @test isa(x, Nullable{R}) && isequal(x, Nullable(op(v1)))
+            x = op(Nullable(v2))
+            @test isa(x, Nullable{R}) && isequal(x, Nullable(op(v2)))
+            x = op(Nullable(v0, true))
+            @test isa(x, Nullable{R}) && isnull(x)
+            x = op(Nullable(v1, true))
+            @test isa(x, Nullable{R}) && isnull(x)
+            x = op(Nullable(v2, true))
+            @test isa(x, Nullable{R}) && isnull(x)
+            x = op(Nullable{R}())
+            @test isa(x, Nullable{R}) && isnull(x)
+        end
+
+        # unsafe unary operators
+        # sqrt
+        @test_throws DomainError sqrt(Nullable(ensure_neg(v1)))
+        R = Base.promote_op(sqrt, T)
+        x = sqrt(Nullable(v0))
+        @test isa(x, Nullable{R}) && isequal(x, Nullable(sqrt(v0)))
+        x = sqrt(Nullable(v1))
+        @test isa(x, Nullable{R}) && isequal(x, Nullable(sqrt(v1)))
+        x = sqrt(Nullable(abs(v2)))
+        @test isa(x, Nullable{R}) && isequal(x, Nullable(sqrt(abs(v2))))
+        x = sqrt(Nullable(v0, true))
+        @test isa(x, Nullable{R}) && isnull(x)
+        x = sqrt(Nullable(ensure_neg(v1), true))
+        @test isa(x, Nullable{R}) && isnull(x)
+        x = sqrt(Nullable(ensure_neg(v2), true))
+        @test isa(x, Nullable{R}) && isnull(x)
+        x = sqrt(Nullable{R}())
+        @test isa(x, Nullable{R}) && isnull(x)
+
+        for u in (u0, u1, u2), v in (v0, v1, v2)
+            # safe binary operators
+            for op in (+, -, *, /, &, |, >>, <<, >>>,
+                       <, >, <=, >=,
+                       Base.scalarmin, Base.scalarmax)
+                (T <: AbstractFloat || S <: AbstractFloat) && op in (&, |, >>, <<, >>>) && continue
+                if VERSION < v"0.5.0-dev"
+                    (T <: Bool || S <: Bool) && op in (>>, <<, >>>) && continue
+                    (T <: BigInt || S <: BigInt) && op in (&, |, >>, <<, >>>) && continue
+                end
+
+                if S <: Unsigned || T <: Unsigned
+                    @test isequal(op(Nullable(abs(u)), Nullable(abs(v))), Nullable(op(abs(u), abs(v))))
+                else
+                    @test isequal(op(Nullable(u), Nullable(v)), Nullable(op(u, v)))
+                end
+                R = Base.promote_op(op, S, T)
+                x = op(Nullable(u, true), Nullable(v, true))
+                @test isa(x, Nullable{R}) && isnull(x)
+                x = op(Nullable(u), Nullable(v, true))
+                @test isa(x, Nullable{R}) && isnull(x)
+                x = op(Nullable(u, true), Nullable(v))
+                @test isa(x, Nullable{R}) && isnull(x)
+            end
+
+            # unsafe binary operators
+            # ^
+            if S <: Integer && T <: Integer && u != 0
+                @test_throws DomainError Nullable(u)^Nullable(ensure_neg(one(v)))
+            end
+            @test isequal(Nullable(u)^Nullable(2*one(T)), Nullable(u^(2*one(T))))
+            R = Base.promote_op(^, S, T)
+            x = Nullable(u, true)^Nullable(-abs(v), true)
+            @test isnull(x) && eltype(x) === R
+            x = Nullable(u, false)^Nullable(-abs(v), true)
+            @test isnull(x) && eltype(x) === R
+            x = Nullable(u, true)^Nullable(-abs(v), false)
+            @test isnull(x) && eltype(x) === R
+
+            # ÷ and %
+            for op in (÷, %)
+                if S <: Integer && T <: Integer && v == 0
+                    @test_throws DivideError op(Nullable(u), Nullable(v))
+                else
+                    @test isequal(op(Nullable(u), Nullable(v)), Nullable(op(u, v)))
+                end
+                R = Base.promote_op(op, S, T)
+                x = op(Nullable(u, true), Nullable(v, true))
+                @test isnull(x) && eltype(x) === R
+                x = op(Nullable(u, false), Nullable(v, true))
+                @test isnull(x) && eltype(x) === R
+                x = op(Nullable(u, true), Nullable(v, false))
+                @test isnull(x) && eltype(x) === R
+            end
+        end
     end
 end


### PR DESCRIPTION
Introduce a new `null_safe_op()` function which is used instead of
`isbits()` to decide whether to take the fast path (without a branch)
or the slow path in lifted operators. This is more correct (and thus
safer), and allows supporting operations on any type. Also add an
extensive set of tests for both paths.

On Julia 0.4, operators for which no functor exist cannot be identified
by `null_safe_op()`: for these, fall back to the slow path on that version.

This PR introduces  `cbrt` as a new supported operation since it has a special
operator `∛`. It also keeps `abs()`, `abs2()`, `scalarmin()` and `scalarmax()`, which
should probably be deprecated once we have a more general solution for
lifting.

Tests pass on Julia 0.4, but on 0.5 they need https://github.com/JuliaLang/julia/pull/16995 (unrelated tests already fail too).

Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/74, https://github.com/JuliaStats/NullableArrays.jl/issues/111, https://github.com/JuliaStats/NullableArrays.jl/issues/116.
