### PR TITLE
map revisions

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -1,91 +1,108 @@
+# if VERSION < v"0.5.0-dev+3294"
+#     include("map0_4.jl")
+# else
+using Base: ith_all
 if VERSION < v"0.5.0-dev+3294"
     include("map0_4.jl")
 else
-    using Base: collect_similar, Generator, ith_all
+    using Base: collect_similar, Generator
+end
 
-    macro nullcheck(Xs, nargs)
-        res = :($(Xs)[1].isnull[i])
-        for i = 2:nargs
-            e = :($(Xs)[$i].isnull[i])
-            res = Expr(:||, res, e)
-        end
-        return res
+macro nullcheck(Xs, nargs)
+    res = :($(Xs)[1].isnull[i])
+    for i = 2:nargs
+        e = :($(Xs)[$i].isnull[i])
+        res = Expr(:||, res, e)
     end
+    return res
+end
 
-    macro fcall(Xs, nargs)
-        res = Expr(:call, :f)
-        for i in 1:nargs
-            push!(res.args, :($(Xs)[$i].values[i]))
-        end
-        return res
+macro fcall(Xs, nargs)
+    res = Expr(:call, :f)
+    for i in 1:nargs
+        push!(res.args, :($(Xs)[$i].values[i]))
     end
+    return res
+end
 
-    # Base.map!
+# Base.map!
 
-    Base.map!{F}(f::F, X::NullableArray; lift=false) = map!(f, X, X; lift=lift)
-    function Base.map!{F}(f::F, dest::NullableArray, X::NullableArray; lift=false)
-        if lift
-            for (i, j) in zip(eachindex(dest), eachindex(X))
-                if X.isnull[j]
-                    dest.isnull[i] = true
-                else
-                    dest.isnull[i] = false
-                    dest.values[i] = f(X.values[j])
-                end
-            end
-        else
-            for (i, j) in zip(eachindex(dest), eachindex(X))
-                dest[i] = f(X[j])
-            end
-        end
-        return dest
-    end
-
-    function Base.map!{F}(f::F, dest::NullableArray, X1::NullableArray,
-                          X2::NullableArray; lift=false)
-        if lift
-            for (i, j, k) in zip(eachindex(dest), eachindex(X1), eachindex(X2))
-                if X1.isnull[j] | X2.isnull[k]
-                    dest.isnull[i] = true
-                else
-                    dest.isnull[i] = false
-                    dest.values[i] = f(X1.values[j], X2.values[k])
-                end
-            end
-        else
-            for (i, j, k) in zip(eachindex(dest), eachindex(X1), eachindex(X2))
-                dest[i] = f(X1[j], X2[k])
-            end
-        end
-        return dest
-    end
-
-    function Base.map!{F}(f::F, dest::NullableArray, Xs::NullableArray...; lift=false)
-        _map!(f, dest, Xs, lift)
-    end
-
-    @generated function _map!{F, N}(f::F, dest::NullableArray, Xs::Tuple{Vararg{NullableArray, N}}, lift)
-        return quote
-            if lift
-                for i in linearindices(Xs[1])
-                    if @nullcheck Xs $N
-                        dest.isnull[i] = true
-                    else
-                        dest.isnull[i] = false
-                        dest.values[i] = @fcall Xs $N
-                    end
-                end
+Base.map!{F}(f::F, X::NullableArray; lift=false) = map!(f, X, X; lift=lift)
+function Base.map!{F}(f::F, dest::NullableArray, X::NullableArray; lift=false)
+    if lift
+        for (i, j) in zip(eachindex(dest), eachindex(X))
+            if X.isnull[j]
+                dest.isnull[i] = true
             else
-                for i in linearindices(Xs[1])
-                    dest[i] = f(ith_all(i, Xs)...)
-                end
+                dest.isnull[i] = false
+                dest.values[i] = f(X.values[j])
             end
-            return dest
+        end
+    else
+        for (i, j) in zip(eachindex(dest), eachindex(X))
+            dest[i] = f(X[j])
         end
     end
+    return dest
+end
 
-    # Base.map
+function Base.map!{F}(f::F, dest::NullableArray, X1::NullableArray,
+                      X2::NullableArray; lift=false)
+    if lift
+        for (i, j, k) in zip(eachindex(dest), eachindex(X1), eachindex(X2))
+            if X1.isnull[j] | X2.isnull[k]
+                dest.isnull[i] = true
+            else
+                dest.isnull[i] = false
+                dest.values[i] = f(X1.values[j], X2.values[k])
+            end
+        end
+    else
+        for (i, j, k) in zip(eachindex(dest), eachindex(X1), eachindex(X2))
+            dest[i] = f(X1[j], X2[k])
+        end
+    end
+    return dest
+end
 
+function Base.map!{F}(f::F, dest::NullableArray, Xs::NullableArray...; lift=false)
+    _map!(f, dest, Xs, lift)
+end
+
+
+@generated function _map!{F, N}(f::F, dest::NullableArray, Xs::NTuple{N, NullableArray}, lift)
+    return quote
+        if lift
+            for i in eachindex(dest)
+                if @nullcheck Xs $N
+                    dest.isnull[i] = true
+                else
+                    dest.isnull[i] = false
+                    dest.values[i] = @fcall Xs $N
+                end
+            end
+        else
+            for i in eachindex(dest)
+                dest[i] = f(ith_all(i, Xs)...)
+            end
+        end
+        return dest
+    end
+end
+
+# Base.map
+
+if VERSION < v"0.5.0-dev+3294"
+    function Base.map(f, X::NullableArray; lift=false)
+        lift ? _liftedmap(f, X) : _map(f, X)
+    end
+    function Base.map(f, X1::NullableArray, X2::NullableArray; lift=false)
+        lift ? _liftedmap(f, X1, X2) : _map(f, X1, X2)
+    end
+    function Base.map(f, Xs::NullableArray...; lift=false)
+        lift ? _liftedmap(f, Xs) : _map(f, Xs...)
+    end
+else
     function Base.map(f, X::NullableArray; lift=false)
         lift ? _liftedmap(f, X) : collect_similar(X, Generator(f, X))
     end
@@ -93,64 +110,110 @@ else
         lift ? _liftedmap(f, X1, X2) : collect(Generator(f, X1, X2))
     end
     function Base.map(f, Xs::NullableArray...; lift=false)
-        lift ? _liftedmap(f, Xs...) : collect(Generator(f, Xs...))
+        lift ? _liftedmap(f, Xs) : collect(Generator(f, Xs...))
     end
+end
 
-    function _liftedmap(f, X::NullableArray)
-        len = length(X)
-        # if X is empty, fall back on type inference
-        len > 0 || return NullableArray{Base.return_types(f, (eltype(X),)), 0}()
+function _liftedmap(f, X::NullableArray)
+    len = length(X)
+    # if X is empty, fall back on type inference
+    len > 0 || return NullableArray{Base.return_types(f, (eltype(X),))[1], 1}()
+    i = 1
+    while X.isnull[i]
+        i += 1
+    end
+    # if X is all null, fall back on type inference
+    i <= len || return similar(X, Base.return_types(f, (eltype(X),))[1])
+    v = f(X.values[i])
+    dest = similar(X, typeof(v))
+    dest[i] = v
+    _liftedmap_to!(f, dest, X, i+1, len)
+end
+
+function _liftedmap(f, X1::NullableArray, X2::NullableArray)
+    len = prod(promote_shape(X1, X2))
+    len > 0 || return NullableArray{Base.return_types(f, (eltype(X1), eltype(X2))), 0}()
+    i = 1
+    while X1.isnull[i] | X2.isnull[i]
+        i += 1
+    end
+    i <= len || return similar(X1, Base.return_types(f, (eltype(X1), eltype(X2))))
+    v = f(X1.values[i], X2.values[i])
+    dest = similar(X1, typeof(v))
+    dest[i] = v
+    _liftedmap_to!(f, dest, X1, X2, i+1, len)
+end
+
+@generated function _liftedmap{N}(f, Xs::NTuple{N, NullableArray})
+    return quote
+        shp = mapreduce(size, promote_shape, Xs)
+        len = prod(shp)
         i = 1
-        while X.isnull[i]
+        while @nullcheck Xs $N
             i += 1
         end
-        # if X is all null, fall back on type inference
-        i <= len || return similar(X, Base.return_types(f, (eltype(X),)))
-        v = f(X.values[i])
-        dest = similar(X, typeof(v))
+        i <= len || return similar(X1, Base.return_types(f, tuple([ eltype(X) for X in Xs ])))
+        v = @fcall Xs $N
+        dest = similar(Xs[1], typeof(v))
         dest[i] = v
-        map_to!(f, dest, X, i+1, len)
+        _liftedmap_to!(f, dest, Xs, i+1, len)
     end
+end
 
-    function _liftedmap(f, X1::NullableArray, X2::NullableArray)
-        len = prod(promote_shape(X1, X2))
-        len > 0 || return NullableArray{Base.return_types(f, (eltype(X1), eltype(X2))), 0}()
-        i = 1
-        while X1.isnull[i] | X2.isnull[i]
+function _liftedmap_to!{T}(f, dest::NullableArray{T}, X, offs, len)
+    # map to dest array, checking the type of each result. if a result does not
+    # match, widen the result type and re-dispatch.
+    i = offs
+    while i <= len
+        @inbounds if X.isnull[i]
+            i += 1; continue
+        end
+        @inbounds el = f(X.values[i])
+        S = typeof(el)
+        if S === T || S <: T
+            @inbounds dest[i] = el::T
             i += 1
-        end
-        i <= len || return similar(X1, Base.return_types(f, (eltype(X1), eltype(X2))))
-        v = f(X1.values[i], X2.values[i])
-        dest = similar(X1, typeof(v))
-        dest[i] = v
-        map_to!(f, dest, X1, X2, i+1, len)
-    end
-
-    @generated function _liftedmap{N}(f, Xs::Vararg{NullableArray, N})
-        return quote
-            shp = size(zip(Xs...))
-            len = prod(shp)
-            i = 1
-            while @nullcheck Xs $N
-                i += 1
-            end
-            i <= len || return similar(X1, Base.return_types(f, tuple([ eltype(X) for X in Xs ])))
-            v = @fcall Xs $N
-            dest = similar(Xs[1], typeof(v))
-            dest[i] = v
-            map_to!(f, dest, Xs, i+1, len)
+        else
+            R = typejoin(T, S)
+            new = similar(dest, R)
+            copy!(new, 1, dest, 1, i-1)
+            @inbounds new[i] = el
+            return map_to!(f, new, X, i+1, len)
         end
     end
+    return dest
+end
 
-    function map_to!{T}(f, dest::NullableArray{T}, X, offs, len)
-        # map to dest array, checking the type of each result. if a result does not
-        # match, widen the result type and re-dispatch.
+function _liftedmap_to!{T}(f, dest::NullableArray{T}, X1, X2, offs, len)
+    i = offs
+    while i <= len
+        @inbounds if X1.isnull[i] | X2.isnull[i]
+            i += 1; continue
+        end
+        @inbounds el = f(X1.values[i], X2.values[i])
+        S = typeof(el)
+        if S === T || S <: T
+            @inbounds dest[i] = el::T
+            i += 1
+        else
+            R = typejoin(T, S)
+            new = similar(dest, R)
+            copy!(new, 1, dest, 1, i-1)
+            @inbounds new[i] = el
+            return map_to!(f, new, X1, X2, i+1, len)
+        end
+    end
+    return dest
+end
+
+@generated function _liftedmap_to!{T, N}(f, dest::NullableArray{T}, Xs::NTuple{N,NullableArray}, offs, len)
+    return quote
         i = offs
         while i <= len
-            @inbounds if X.isnull[i]
+            @inbounds if @nullcheck Xs $N
                 i += 1; continue
             end
-            @inbounds el = f(X.values[i])
+            @inbounds el = @fcall Xs $N
             S = typeof(el)
             if S === T || S <: T
                 @inbounds dest[i] = el::T
@@ -160,55 +223,9 @@ else
                 new = similar(dest, R)
                 copy!(new, 1, dest, 1, i-1)
                 @inbounds new[i] = el
-                return map_to!(f, new, X, i+1, len)
+                return map_to!(f, new, Xs, i+1, len)
             end
         end
         return dest
-    end
-
-    function map_to!{T}(f, dest::NullableArray{T}, X1, X2, offs, len)
-        i = offs
-        while i <= len
-            @inbounds if X1.isnull[i] | X2.isnull[i]
-                i += 1; continue
-            end
-            @inbounds el = f(X1.values[i], X2.values[i])
-            S = typeof(el)
-            if S === T || S <: T
-                @inbounds dest[i] = el::T
-                i += 1
-            else
-                R = typejoin(T, S)
-                new = similar(dest, R)
-                copy!(new, 1, dest, 1, i-1)
-                @inbounds new[i] = el
-                return map_to!(f, new, X1, X2, i+1, len)
-            end
-        end
-        return dest
-    end
-
-    @generated function map_to!{T, N}(f, dest::NullableArray{T}, Xs::Tuple{Vararg{NullableArray, N}}, offs, len)
-        return quote
-            i = offs
-            while i <= len
-                @inbounds if @nullcheck Xs $N
-                    i += 1; continue
-                end
-                @inbounds el = @fcall Xs $N
-                S = typeof(el)
-                if S === T || S <: T
-                    @inbounds dest[i] = el::T
-                    i += 1
-                else
-                    R = typejoin(T, S)
-                    new = similar(dest, R)
-                    copy!(new, 1, dest, 1, i-1)
-                    @inbounds new[i] = el
-                    return map_to!(f, new, Xs, i+1, len)
-                end
-            end
-            return dest
-        end
     end
 end

--- a/src/map0_4.jl
+++ b/src/map0_4.jl
@@ -1,0 +1,172 @@
+using Base.Cartesian
+
+function gen_nullcheck(narrays::Int)
+    As = [Symbol("A_"*string(i)) for i = 1:narrays]
+    e_nullcheck = :($(As[1]).isnull[i])
+    for i = 2:narrays
+        e_nullcheck = Expr(:||, e_nullcheck, :($(As[i]).isnull[i]))
+    end
+    return e_nullcheck
+end
+
+function gen_map!_body{F}(narrays::Int, lift::Bool, f::F)
+    _f = Expr(:quote, f)
+    e_nullcheck = gen_nullcheck(narrays)
+    if lift
+        return quote
+            for i in 1:length(dest)
+                if $e_nullcheck
+                    dest.isnull[i] = true
+                else
+                    dest[i] = $_f((@ntuple $narrays j->A_j.values[i])...)
+                end
+            end
+        end
+    else
+        return quote
+            for i in 1:length(dest)
+                dest[i] = $_f((@ntuple $narrays j->A_j[i])...)
+            end
+        end
+    end
+end
+
+function gen_map_to!_body{F}(_map_to!::Symbol, narrays::Int, f::F)
+    _f = Expr(:quote, f)
+    e_nullcheck = gen_nullcheck(narrays)
+    return quote
+        @inbounds for i in offs:length(A_1)
+            if lift
+                if $e_nullcheck
+                    # we don't need to compute anything if A.isnull[i], since
+                    # the return type is specified by T and by the algorithm in
+                    # 'body'
+                    dest.isnull[i] = true
+                    continue
+                else
+                    v = $_f((@ntuple $narrays j->A_j.values[i])...)
+                end
+            else
+                v = $_f((@ntuple $narrays j->A_j[i])...)
+            end
+            S = typeof(v)
+            if S !== T && !(S <: T)
+                R = typejoin(T, S)
+                new = similar(dest, R)
+                copy!(new, 1, dest, 1, i - 1)
+                new[i] = v
+                return $(_map_to!)(new, i + 1, (@ntuple $narrays j->A_j)...; lift=lift)
+            end
+            dest[i] = v::T
+        end
+        return dest
+    end
+end
+
+function gen_map_body{F}(_map_to!::Symbol, narrays::Int, f::F)
+    _f = Expr(:quote, f)
+    e_nullcheck = gen_nullcheck(narrays)
+    if narrays == 1
+        pre = quote
+            isempty(A_1) && return isa(f, Type) ? similar(A_1, f) : similar(A_1)
+        end
+    else
+        pre = quote
+            shape = mapreduce(size, promote_shape, (@ntuple $narrays j->A_j))
+            prod(shape) == 0 && return similar(A_1, promote_type((@ntuple $narrays j->A_j)...), shape)
+        end
+    end
+    return quote
+        $pre
+        i = 1
+        # find first non-null entry in A_1, ... A_narrays
+        if lift == true
+            emptyel = $e_nullcheck
+            while (emptyel && i < length(A_1))
+                i += 1
+                emptyel &= $e_nullcheck
+            end
+            # if all entries are null, return a similar
+            i == length(A_1) && return isa(f, Type) ? similar(A_1, f) : similar(A_1)
+            v = $_f((@ntuple $narrays j->A_j.values[i])...)
+        else
+            v = $_f((@ntuple $narrays j->A_j[i])...)
+        end
+        dest = similar(A_1, typeof(v))
+        dest[i] = v
+        return $(_map_to!)(dest, i + 1, (@ntuple $narrays j->A_j)...; lift=lift)
+    end
+end
+
+function gen_map!_function{F}(narrays::Int, lift::Bool, f::F)
+    As = [Symbol("A_"*string(i)) for i = 1:narrays]
+    body = gen_map!_body(narrays, lift, f)
+    @eval let
+        local _F_
+        function _F_(dest, $(As...))
+            $body
+        end
+        _F_
+    end
+end
+
+function gen_map_function{F}(_map_to!::Symbol, narrays::Int, f::F)
+    As = [Symbol("A_"*string(i)) for i = 1:narrays]
+    body_map_to! = gen_map_to!_body(_map_to!, narrays, f)
+    body_map = gen_map_body(_map_to!, narrays, f)
+
+    @eval let $_map_to! # create a closure for subsequent calls to $_map_to!
+        function $(_map_to!){T}(dest::NullableArray{T}, offs, $(As...); lift::Bool=false)
+            $body_map_to!
+        end
+        local _F_
+        function _F_($(As...); lift::Bool=false)
+            $body_map
+        end
+        return _F_
+    end # let $_map_to!
+end
+
+# Base.map!
+@eval let cache = Dict{Bool, Dict{Int, Dict{Base.Callable, Function}}}()
+    @doc """
+    `map!{F}(f::F, dest::NullableArray, As::AbstractArray...; lift::Bool=false)`
+    This method implements the same behavior as that of `map!` when called on
+    regular `Array` arguments. It also includes the `lift` keyword argument, which
+    when set to true will lift `f` over the entries of the `As`. Lifting is
+    disabled by default.
+    """ ->
+    function Base.map!{F}(f::F, dest::NullableArray, As::AbstractArray...;
+                          lift::Bool=false)
+        narrays = length(As)
+
+        cache_lift  = Base.@get!  cache         lift    Dict{Int, Dict{Base.Callable, Function}}()
+        cache_f     = Base.@get!  cache_lift    narrays Dict{Base.Callable, Function}()
+        func        = Base.@get!  cache_f       f       gen_map!_function(narrays, lift, f)
+
+        func(dest, As...)
+        return dest
+    end
+end
+
+Base.map!{F}(f::F, X::NullableArray; lift::Bool=false) = map!(f, X, X; lift=lift)
+
+# Base.map
+@eval let cache = Dict{Int, Dict{Base.Callable, Function}}()
+    @doc """
+    `map{F}(f::F, As::AbstractArray...; lift::Bool=false)`
+    This method implements the same behavior as that of `map!` when called on
+    regular `Array` arguments. It also includes the `lift` keyword argument, which
+    when set to true will lift `f` over the entries of the `As`. Lifting is
+    disabled by default.
+    """ ->
+    function Base.map{F}(f::F, As::NullableArray...; lift::Bool=false)
+        narrays = length(As)
+        _map_to! = gensym()
+
+        cache_fs    = Base.@get!  cache     narrays  Dict{Base.Callable, Function}()
+        _map        = Base.@get!  cache_fs  f        gen_map_function(_map_to!, narrays, f)
+
+        return _map(As...; lift=lift)
+    end
+end

--- a/test/map.jl
+++ b/test/map.jl
@@ -74,7 +74,6 @@ module TestMap
         map(g, args[1][i], args[1][j])
         map(g, args[2][i], args[2][j]; lift=true)
         @test isequal(dests[2], NullableArray(dests[1], mask...))
-        println(4)
     end
     # n arg
     for (args, mask) in (
@@ -97,4 +96,66 @@ module TestMap
         map(g, args[2]...; lift=true)
         @test isequal(dests[2], NullableArray(dests[1], mask...))
     end
+
+    # test map over empty NullableArrays
+    X = NullableArray(Int[])
+    h1(x) = 5.0*x
+    h2(x::Nullable) = x
+    h2(x::Nullable...) = prod(x)
+
+    Z1 = map(h1, X)
+    Z2 = map(h2, X)
+    if VERSION >= v"0.5.0-dev+3294"
+        @test isequal(Z1, NullableArray(Union{}[])) # no type inference
+    end
+    if VERSION >= v"0.5.0-dev+5297"
+        @test isequal(Z2, NullableArray(Float64[])) # use type inference
+    end
+
+    Z1 = map(h1, X; lift=true) # use type inference
+    @test isequal(Z1, NullableArray(Int64[]))
+
+    # if a function has no method for inner_eltype of empty NullableArray,
+    # result should be empty NullableArray{Union{}}()
+    h3(x::Float64...) = prod(x)
+    Z3 = map(h3, X)
+    @test isequal(Z3, NullableArray(Union{}[]))
+    Z3 = map(h3, X, X)
+    @test isequal(Z3, NullableArray(Union{}[]))
+    Z3 = map(h3, X, X, X)
+    @test isequal(Z3, NullableArray(Union{}[]))
+    Z3 = map(h3, X; lift=true)
+    @test isequal(Z3, NullableArray(Union{}[]))
+    Z3 = map(h3, X, X; lift=true)
+    @test isequal(Z3, NullableArray(Union{}[]))
+    Z3 = map(h3, X, X, X; lift=true)
+    @test isequal(Z3, NullableArray(Union{}[]))
+
+    # test map over all null NullableArray
+    n = rand(10:100)
+    Ys = [ NullableArray(rand(Int, n), fill(true, n)) for i in 1:rand(3:5) ]
+
+    Z2 = map(h2, Ys[1]) # behavior should be determined solely by h2, i.e. no type inference
+    @test isequal(Z2, NullableArray(Int, n))
+    Z2 = map(h2, Ys[1], Ys[2])
+    @test isequal(Z2, NullableArray(Int, n))
+    Z2 = map(h2, Ys...)
+    @test isequal(Z2, NullableArray(Int, n))
+
+    Z1 = map(h1, Ys[1]; lift=true) # fall back on type inference
+    @test isequal(Z1, NullableArray(Float64, n))
+    Z1 = map(h1, Ys[1], Ys[2]; lift=true)
+    @test isequal(Z1, NullableArray(Float64, n))
+    Z1 = map(h1, Ys...; lift=true)
+    @test isequal(Z1, NullableArray(Float64, n))
+
+    # if a function has no method for inner_eltype of all null NullableArray,
+    # result of lifted map should be NullableArray{Union{}}()
+    h4(x::Int...) = prod(x)
+    Z4 = map(h4, Ys[1]; lift=true)
+    @test isequal(Z4, NullableArray(Union{}, n))
+    Z4 = map(h4, Ys[1], Ys[2]; lift=true)
+    @test isequal(Z4, NullableArray(Union{}, n))
+    Z4 = map(h4, Ys...; lift=true)
+    @test isequal(Z4, NullableArray(Union{}, n))
 end # module TestMap

--- a/test/map.jl
+++ b/test/map.jl
@@ -2,9 +2,11 @@ module TestMap
     using Base.Test
     using NullableArrays
 
+    # create m random arrays each with N dimensions and length dims[i] along
+    # dimension i for i=1:N
     N = rand(2:5)
     dims = Int[ rand(3:8) for i in 1:N ]
-    m = rand(2:5)
+    m = rand(3:5)
     As = [ rand(dims...) for i in 1:m ]
 
     Ms = [ rand(Bool, dims...) for i in 1:m ]
@@ -27,49 +29,72 @@ module TestMap
 
     dests = (C, Z)
 
-    for (args, mask) in (
-        ((As, Xs), ()), ((As, Ys), (R,))
-    )
-
-        # Base.map!{F}(f::F, dest::NullableArray, As::AbstractArray...;
-        #              lift::Bool=false)
-        map!(f, dests[1], args[1]...)
-        map!(f, dests[2], args[2]...)
-        @test isequal(dests[2], NullableArray(dests[1], mask...))
-
-        map!(g, dests[1], args[1]...)
-        map!(g, dests[2], args[2]...; lift=true)
-        @test isequal(dests[2], NullableArray(dests[1], mask...))
-
-        # Base.map{F}(f::F, As::NullableArray...; lift::Bool=false)
-        map(f, args[1]...)
-        map(f, args[2]...)
-        @test isequal(dests[2], NullableArray(dests[1], mask...))
-
-        map!(g, args[1]...)
-        map!(g, args[2]...; lift=true)
-        @test isequal(dests[2], NullableArray(dests[1], mask...))
-    end
-
+    # 1 arg
     for (args, masks) in (
         ((As, Xs), fill((), m)), ((As, Ys), [ (Ms[i],) for i in 1:m ])
     )
         for i in 1:m
-            map!(f, args[1][i])
-            map!(f, args[2][i])
+            # map!
+            map!(f, args[1][i]) # map!(f, As[i])
+            map!(f, args[2][i]) # map!(f, Xs[i])
             @test isequal(args[2][i], NullableArray(args[1][i], masks[i]...))
-
-            A = map(f, args[1][i])
-            X = map(f, args[2][i])
-            @test isequal(X, NullableArray(A, masks[i]...))
-
+            # lifted map!
             map!(g, args[1][i])
             map!(g, args[2][i]; lift=true)
             @test isequal(args[2][i], NullableArray(args[1][i], masks[i]...))
-
+            # map
+            A = map(f, args[1][i])
+            X = map(f, args[2][i])
+            @test isequal(X, NullableArray(A, masks[i]...))
+            # lifted map
             A = map(f, args[1][i])
             X = map(g, args[2][i]; lift=true)
             @test isequal(X, NullableArray(A, masks[i]...))
         end
+    end
+    # 2 arg
+    i, j = rand(1:m), rand(1:m)
+    S = map(|, Ms[i], Ms[j])
+    for (args, mask) in (
+        ((As, Xs), ()), ((As, Ys), (S,))
+    )
+        # map!
+        map!(f, dests[1], args[1][i], args[1][j])
+        map!(f, dests[2], args[2][i], args[2][j])
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        # lifted map!
+        map!(g, dests[1], args[1][i], args[1][j])
+        map!(g, dests[2], args[2][i], args[2][j]; lift=true)
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        # map
+        map(f, args[1][i], args[1][j])
+        map(f, args[2][i], args[2][j])
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        # lifted map
+        map(g, args[1][i], args[1][j])
+        map(g, args[2][i], args[2][j]; lift=true)
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        println(4)
+    end
+    # n arg
+    for (args, mask) in (
+        ((As, Xs), ()), ((As, Ys), (R,))
+    )
+        # map!
+        map!(f, dests[1], args[1]...)
+        map!(f, dests[2], args[2]...)
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        # lifted map!
+        map!(g, dests[1], args[1]...)
+        map!(g, dests[2], args[2]...; lift=true)
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        # map
+        map(f, args[1]...)
+        map(f, args[2]...)
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
+        # lifted map
+        map(g, args[1]...)
+        map(g, args[2]...; lift=true)
+        @test isequal(dests[2], NullableArray(dests[1], mask...))
     end
 end # module TestMap


### PR DESCRIPTION
This is an attempt to transition away from the metaprogramming-heavy approach to map we took for Julia v0.4. Admittedly, this does introduce the use of generated functions in n-arg `map`/`map!`. ~~Does anybody have any suggestions as to how best maintain compatibility with 0.4? What I have here seems kind of crude.~~

There's a lot of code repetition due to the 1-arg, 2-arg and n-arg methods for `map`. The Base `map(f, A)` regime calls `collect_similar(A, Generator(f, A))`, but I haven't found a way to `collect` over a `Generator{NullableArray, F}` without creating a lot of unnecessary `Nullable` objects -- so, hooking into that interface isn't really an option. I'm not sure the best way to reduce the code footprint here.

Here are the significant points for this PR:
- fix #130
- remove as much dependence on metaprogramming as possible
- Settle on well-defined behavior for the two "emtpy" cases: (i) `map` over empty `NullableArray` and (ii) `map over non-empty but all-null`NullableArray`. 

For both cases (i) and (ii) above, the call to `map` can be lifted or not. If `map` is not lifted, it falls back on the implementation in Base, which differs between 0.4 and 0.5 (and also between the 1-arg, 2-arg and n-arg implementations). On 0.5, we have the following four combinations of behaviors:

1) `map(f, X; lift=false)`, where `X` is empty. On 0.5, now that https://github.com/JuliaLang/julia/pull/16622 has been merged, this uses type inference (`Base.return_types`) to select the type parameter for the returned empty `NullableArray{T}`. Note that, since `f` is not lifted, `return_types` is called on `f, (eltype(X),)`. If somewhere down the line a method specialized on `Nullable` arguments is missing, this will return an empty `NullableArray{Union{}}`:

``` julia
julia> X = NullableArray(Int[])
0-element NullableArrays.NullableArray{Int64,1}

julia> f(x) = 5*x
f (generic function with 1 method)

julia> map(f, X)
0-element NullableArrays.NullableArray{Union{},1}

julia> h(x::Nullable) = Nullable(5*x.value, x.isnull)
h (generic function with 1 method)

julia> map(h, X)
0-element NullableArrays.NullableArray{Int64,1}
```

2) `map(f, X; lift=true)`, where `X` is empty. This uses type inference (`Base.return_types`) to select the type parameter for the returned empty `NullableArray`. Since `f` is lifted, `return_types` is called on `f, (inner_eltype(X),)`, where `inner_eltype(X::NullableArray{T}) = T`:

``` julia
julia> map(f, X; lift=true)
0-element NullableArrays.NullableArray{Int64,1}
```

3) `map(f, X; lift=false)` where `X` is non-empty but all null. The returned `NullableArray{T}` does _not_ depend on type inference --- it depends entirely on the behavior of `f` applied to empty `Nullable{T}` objects.

``` julia
julia> map(f, Y)
ERROR: MethodError: no method matching *(::Int64, ::Nullable{Int64})
Closest candidates are:
  *(::Any, ::Any, ::Any, ::Any...)
  *{S}(::Nullable{Union{}}, ::Nullable{S})
  *{T<:Union{Int128,Int16,Int32,Int64,Int8,UInt128,UInt16,UInt32,UInt64,UInt8}}(::T<:Union{Int128,Int16,Int32,Int64,Int8,UInt128,UInt16,UInt32,UInt64,UInt8}, ::T<:Union{Int128,Int16,Int32,Int64,Int8,UInt128,UInt16,UInt32,UInt64,UInt8})
  ...
 in _collect(::NullableArrays.NullableArray{Int64,1}, ::Base.Generator{NullableArrays.NullableArray{Int64,1},#f}, ::Base.EltypeUnknown, ::Base.HasShape) at ./array.jl:283
 in #map#11 at /Users/David/.julia/v0.5/NullableArrays/src/map.jl:108 [inlined]
 in map(::Function, ::NullableArrays.NullableArray{Int64,1}) at /Users/David/.julia/v0.5/NullableArrays/src/map.jl:108
 in eval(::Module, ::Any) at ./boot.jl:234
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46

julia> map(h, Y)
3-element NullableArrays.NullableArray{Int64,1}:
 #NULL
 #NULL
 #NULL
```

4) `map(f, X; lift=true)` where `X` is non-empty but all null. This _does_ use type inference to determine the return type of the returned `NullableArray`. 

``` julia
julia> map(f, Y; lift=true)
3-element NullableArrays.NullableArray{Int64,1}:
 #NULL
 #NULL
 #NULL
```

Brief performance summary (on 0.5) (NOTE: revised as of 7/12/16):

``` julia
using NullableArrays
using BenchmarkTools
n = 1_000_000
A = rand(n)
M = rand(Bool, n)
X = NullableArray(A)
Y = NullableArray(A, M)
As = [ rand(n) for i in 1:5 ]
Ms = [ rand(Bool, n) for i in 1:5 ]
Xs = [ NullableArray(A) for A in As ]
Ys = [ NullableArray(A, M) for (A, M) in zip(As, Ms)]
f(x) = 5*x
f(x::Nullable) = Nullable(5)*x
f(xs...) = prod(xs)

julia> @benchmark map(f, A)
BenchmarkTools.Trial: 
  samples:          1094
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  7.63 mb
  allocs estimate:  4
  minimum time:     2.79 ms (0.00% GC)
  median time:      3.38 ms (0.00% GC)
  mean time:        4.57 ms (21.49% GC)
  maximum time:     21.65 ms (0.00% GC)

julia> @benchmark map(f, X)
BenchmarkTools.Trial: 
  samples:          400
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  8.58 mb
  allocs estimate:  12
  minimum time:     9.47 ms (0.00% GC)
  median time:      12.01 ms (0.00% GC)
  mean time:        12.51 ms (8.02% GC)
  maximum time:     36.04 ms (0.00% GC)

julia> @benchmark map(f, X; lift=true)
BenchmarkTools.Trial: 
  samples:          895
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  8.58 mb
  allocs estimate:  9
  minimum time:     3.83 ms (0.00% GC)
  median time:      4.59 ms (0.00% GC)
  mean time:        5.58 ms (16.47% GC)
  maximum time:     65.67 ms (0.00% GC)

julia> @benchmark map(f, Y)
BenchmarkTools.Trial: 
  samples:          298
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  8.58 mb
  allocs estimate:  12
  minimum time:     14.41 ms (0.00% GC)
  median time:      16.95 ms (0.00% GC)
  mean time:        16.82 ms (5.38% GC)
  maximum time:     21.59 ms (18.36% GC)

julia> @benchmark map(f, Y; lift=true)
BenchmarkTools.Trial: 
  samples:          582
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  8.58 mb
  allocs estimate:  9
  minimum time:     6.05 ms (0.00% GC)
  median time:      7.84 ms (0.00% GC)
  mean time:        8.60 ms (12.49% GC)
  maximum time:     28.21 ms (44.18% GC)

julia> @benchmark map(f, As...)
BenchmarkTools.Trial: 
  samples:          222
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  7.63 mb
  allocs estimate:  9
  minimum time:     19.83 ms (0.00% GC)
  median time:      22.67 ms (0.00% GC)
  mean time:        22.59 ms (4.04% GC)
  maximum time:     30.93 ms (8.61% GC)

@benchmark map(f, Xs...)
BenchmarkTools.Trial: 
  samples:          2
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  2.10 gb
  allocs estimate:  61995904
  minimum time:     4.87 s (9.77% GC)
  median time:      4.97 s (9.63% GC)
  mean time:        4.97 s (9.63% GC)
  maximum time:     5.07 s (9.49% GC)

julia> @benchmark map(f, Xs...; lift=true)
BenchmarkTools.Trial: 
  samples:          291
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  8.58 mb
  allocs estimate:  15
  minimum time:     12.57 ms (0.00% GC)
  median time:      15.94 ms (0.00% GC)
  mean time:        17.18 ms (5.67% GC)
  maximum time:     80.23 ms (0.00% GC)

julia> @benchmark map(f, Ys...)
BenchmarkTools.Trial: 
  samples:          1
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  2.10 gb
  allocs estimate:  61995904
  minimum time:     5.30 s (9.30% GC)
  median time:      5.30 s (9.30% GC)
  mean time:        5.30 s (9.30% GC)
  maximum time:     5.30 s (9.30% GC)

@benchmark map(f, Ys...; lift=true)
BenchmarkTools.Trial: 
  samples:          350
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  8.58 mb
  allocs estimate:  15
  minimum time:     12.21 ms (0.00% GC)
  median time:      14.08 ms (0.00% GC)
  mean time:        14.31 ms (6.22% GC)
  maximum time:     22.85 ms (11.79% GC)
```

~~It seems pretty clear that, as far as performance goes, we ought to transition towards lifting by default. I think this seems reasonable for most statistics/data science-related use cases. To do so, would we need to deprecate the current behavior for a release cycle?~~ [7/12/16]: Lifting will probably yield best performance, but clearly something is sub-optimal with the (n-arg especially) non-lifted `map` implementation.  

@nalimilan @johnmyleswhite thoughts?
