### PR TITLE
fix deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-Compat 0.7.14
+Compat 0.8.4
 Reexport

--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -3,6 +3,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 module NullableArrays
 
 using Compat
+using Compat.view
 using Reexport
 @reexport using Base.Cartesian
 

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -40,7 +40,7 @@ end
 
 @generated function anynull{T, N, U<:NullableArray}(S::SubArray{T, N, U})
     return quote
-        isnull = slice(S.parent.isnull, S.indexes...)
+        isnull = view(S.parent.isnull, S.indexes...)
         @nloops $N i S begin
             (@nref $N isnull i) && (return true)
         end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,6 +1,7 @@
 module TestPrimitives
     using Base.Test
     using NullableArrays
+    using Compat.view
 
     n = rand(1:5)
     siz = [ rand(2:5) for i in n ]
@@ -186,11 +187,11 @@ module TestPrimitives
     M = rand(Bool, 10, 3, 3)
     X = NullableArray(A, M)
     i, j = rand(1:3), rand(1:3)
-    S = slice(X, :, i, j)
+    S = view(X, :, i, j)
 
     @test anynull(S) == anynull(X[:, i, j])
     X = NullableArray(A)
-    S = slice(X, :, i, j)
+    S = view(X, :, i, j)
     @test anynull(S) == false
 
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -2,6 +2,7 @@ module TestSubArray
 
 using Base.Test
 using NullableArrays
+using Compat.view
 
 nd = rand(3:5)
 sz = [ rand(3:10) for i in 1:nd ]
@@ -12,7 +13,7 @@ H = [ rand(1:sz[i]) for i in 1:nd ]
 
 for i in 1:nd
     J = [ (x->x==i ? I[x] : Colon())(j) for j in 1:nd ]
-    S = slice(X, J...)
+    S = view(X, J...)
     H = [ (x->x==i ? I[x] : rand(1:sz[x]))(j) for j in 1:nd ]
     _H = H[find(x->x!=i, collect(1:nd))]
 


### PR DESCRIPTION
Fixes deprecations on `Julia v0.5`. `Compat` pinned to `0.8.4` to make use of `view`.
