### PR TITLE
Address issues #124, #125

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -32,6 +32,9 @@ function NullableArray(T::Type, dims::Int...) # -> NullableArray
     return NullableArray(T, dims)
 end
 
+@compat (::Type{NullableArray{T}}){T}(dims::Dims) = NullableArray(T, dims)
+@compat (::Type{NullableArray{T}}){T}(dims::Int...) = NullableArray(T, dims)
+
 # The following method constructs a NullableArray from an Array{Any} argument
 # 'A' that contains some placeholder of type 'T' for null values.
 #
@@ -85,7 +88,6 @@ end
 
 # The following method allows for the construction of zero-element
 # NullableArrays by calling the parametrized type on zero arguments.
-# TODO: add support for dimensions arguments?
 @compat (::Type{NullableArray{T, N}}){T, N}() = NullableArray(T, ntuple(i->0, N))
 
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -5,7 +5,7 @@ Base.linearindexing{T <: NullableArray}(::Type{T}) = LinearFast()
 
 # resolve ambiguity created by the two definitions that follow.
 function Base.getindex{T, N}(X::NullableArray{T, N})
-    return X
+    return X[1]
 end
 
 @doc """

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -41,13 +41,39 @@ module TestConstructors
     @test isa(u2, NullableMatrix{Int})
     @test isa(u3, NullableArray{Int, 3})
 
-    # test (::Type{T}, dims::Dims...) constructor
+    # test (::Type{T}, dims::Int...) constructor
     x1 = NullableArray(Int, 2)
     x2 = NullableArray(Int, 2, 2)
     x3 = NullableArray(Int, 2, 2, 2)
     @test isa(x1, NullableVector{Int})
     @test isa(x2, NullableMatrix{Int})
     @test isa(x3, NullableArray{Int, 3})
+
+    # test NullableArray{T}(dims::Dims)
+    d1, d2 = rand(1:100), rand(1:100)
+    X1 = NullableArray{Int}((d1,))
+    X2 = NullableArray{Int}((d1, d2))
+    @test isequal(X1, NullableArray(Array{Int}((d1,)), fill(true, (d1,))))
+    @test isequal(X2, NullableArray(Array{Int}((d1, d2)), fill(true, (d1, d2))))
+    for i in 1:5
+        m = rand(3:5)
+        dims = tuple([ rand(1:5) for i in 1:m ]...)
+        X3 = NullableArray{Int}(dims)
+        @test isequal(X3, NullableArray(Array{Int}(dims), fill(true, dims)))
+    end
+
+    # test NullableArray{T}(dims::Int...)
+    d1, d2 = rand(1:100), rand(1:100)
+    X1 = NullableArray{Int}(d1)
+    X2 = NullableArray{Int}(d1, d2)
+    @test isequal(X1, NullableArray(Array{Int}(d1), fill(true, d1)))
+    @test isequal(X2, NullableArray(Array{Int}(d1, d2), fill(true, d1, d2)))
+    for i in 1:5
+        m = rand(3:5)
+        dims = [ rand(1:5) for i in 1:m ]
+        X3 = NullableArray{Int}(dims...)
+        @test isequal(X3, NullableArray(Array{Int}(dims...), fill(true, dims...)))
+    end
 
     # test (A::AbstractArray, ::Type{T}, ::Type{U}) constructor
     z = NullableArray([1, nothing, 2, nothing, 3], Int, Void)
@@ -63,10 +89,9 @@ module TestConstructors
     Y = NullableArray([1, nothing, 2, 3, 4, 5, nothing], Int, Void)
     @test isequal(Y, Z)
 
-    # test parameterized type constructor with no arguments
-    @test isequal(NullableVector{Int}(), NullableArray{Int, 1}([]))
-    @test isequal(NullableArray{Bool, 2}(),
-                  NullableArray{Bool, 2}(Array(Bool, 0, 0)))
+    # test NullableArray{T}()
+    X = NullableArray{Int}()
+    @test isequal(size(X), ())
 
     # test conversion from arrays, arrays of nullables and NullableArrays
     miss1 = [false,false,false,false]

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -31,8 +31,7 @@ module TestIndexing
     X = NullableArray(_values, _isnull)
 
     # Base.getindex{T, N}(X::NullableArray{T, N})
-    @test isequal(getindex(X), X)
-    @test getindex(X) === X
+    @test isequal(getindex(X), X[1])
 
     # Base.getindex{T, N}(X::NullableArray{T, N}, I::Nullable{Int}...)
     @test_throws NullException getindex(X, Nullable{Int}(), Nullable{Int}())

--- a/test/show.jl
+++ b/test/show.jl
@@ -48,6 +48,11 @@ for typ in (Float64, Int, UInt, Char)
     display(disp, Y3)
     typeof(X3)
     typeof(Y3)
+
+    X = NullableArray{typ}()
+    show(io, X)
+    display(disp, X)
+    typeof(X)
 end
 
 end # module TestShow


### PR DESCRIPTION
Includes tests.

Worth noting that the bug in #124 involved how we treated `getindex(X::NullableArray)`. A reminder that we could stand to review our general indexing strategy and its coordination with that in Base for `AbstractArray`s. 
