### PR TITLE
Fix missing type in copy(X)

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -26,7 +26,7 @@ end
 Return a shallow copy of `X`; the outer structure of `X` will be copied, but
 all elements will be identical to those of `X`.
 """ ->
-Base.copy(X::NullableArray) = Base.copy!(similar(X), X)
+Base.copy{T}(X::NullableArray{T}) = Base.copy!(similar(X, T), X)
 
 @doc """
 `copy!(dest::NullableArray, src::NullableArray)`


### PR DESCRIPTION
There was a bug in `copy(X)` that caused it to generate `NullableArray{Any}` instead of `NullableArray{T}` sometimes. It's possible that we are also still missing a `similar` method as the documentation for `similar` makes `T` seem optional, but it doesn't seem to be.
