### PR TITLE
Add appropriate no-op convert method

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -123,6 +123,8 @@ function Base.convert{S, T, N}(::Type{NullableArray{T, N}},
 end
 
 #----- Conversion from NullableArrays of a different type --------------------#
+Base.convert{T, N}(::Type{NullableArray}, X::NullableArray{T,N}) = X
+
 function Base.convert{S, T, N}(::Type{NullableArray{T}},
                                A::AbstractArray{Nullable{S}, N}) # -> NullableArray{T, N}
     convert(NullableArray{T, N}, A)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -123,4 +123,11 @@ module TestConstructors
         @test isa(convert(NullableArray{Float64,1}, a), NullableArray{Float64,1})
         @test isequal(convert(NullableArray{Float64,1}, a), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],miss))
     end
+
+    # converting a NullableArray to unqualified type NullableArray should be no-op
+    m = rand(10:100)
+    A = rand(m)
+    M = rand(Bool, m)
+    X = NullableArray(A, M)
+    @test X === convert(NullableArray, X)
 end


### PR DESCRIPTION
`convert{T,N}(::Type{NullableArray}, X::NullableArray{T,N})` should be a no-op.
