### PR TITLE
Add reshape(::NullableArray, shp) method

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -108,6 +108,10 @@ function Base.resize!{T}(X::NullableArray{T,1}, n::Int) # -> NullableArray{T, 1}
     return X
 end
 
+function Base.reshape(X::NullableArray, dims::Dims) # -> NullableArray
+    NullableArray(reshape(X.values, dims), reshape(X.isnull, dims))
+end
+
 @doc """
 `ndims(X::NullableArray)`
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -134,6 +134,19 @@ module TestPrimitives
     @test Y1.values[1:5] == Y.values[1:5]
     @test Y1.isnull[1:5] == Y.isnull[1:5]
 
+# ----- test Base.reshape ----------------------------------------------------#
+
+    Y1 = reshape(copy(Y), length(Y), 1)
+    @test size(Y1) == (length(Y), 1)
+    @test all(i->isequal(Y1[i], Y[i]), 1:length(Y))
+    Y2 = reshape(Y1, 1, length(Y1))
+    @test size(Y2) == (1, length(Y1))
+    @test all(i->isequal(Y1[i], Y2[i]), 1:length(Y2))
+    # Test that arrays share the same data
+    Y2.values[1] += 1
+    Y2.isnull[2] = true
+    @test all(i->isequal(Y1[i], Y2[i]), 1:length(Y2))
+
 # ----- test Base.ndims ------------------------------------------------------#
 
     for n in 1:4


### PR DESCRIPTION
Without this, the fallback ReshapedArray is used, which is unnecessarily
complex, and creates issues e.g. when trying to convert the result to an
Array{T}.

---

The interaction between `NullableArrays`, `reshape` and `convert` currently doesn't work very well. While NullableArrays.jl provides methods allowing conversion to `Array`, these do not apply to reshaped `NullableArrays`. In particular, this means one cannot reshape a `NullableVector` to a matrix in order to convert it to a `Matrix` (which is needed e.g. to build model matrices):

``` julia
julia> using NullableArrays

julia> convert(Matrix{Int}, reshape(NullableArray([1,2]), 2, 1))
ERROR: MethodError: Cannot `convert` an object of type Nullable{Int64} to an object of type Int64
This may have arisen from a call to the constructor Int64(...),
since type constructors fall back to convert methods.
 in copy!(::Base.LinearFast, ::Array{Int64,2}, ::Base.LinearFast, ::Base.ReshapedArray{Nullable{Int64},2,NullableArrays.NullableArray{Int64,1},Tuple{}}) at ./abstractarray.jl:551
 in convert(::Type{Array{Int64,2}}, ::Base.ReshapedArray{Nullable{Int64},2,NullableArrays.NullableArray{Int64,1},Tuple{}}) at ./array.jl:233

```

This PR fixes the above error.
