### PR TITLE
Widen dropnull() and allnull() signatures

### DIFF
--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -148,51 +148,50 @@ function Base.find(X::NullableArray{Bool}) # -> Array{Int}
     return res
 end
 
-@doc """
-`dropnull(X::NullableVector)`
 
-Return a `Vector` containing only the non-null entries of `X`.
+_isnull(x::Any) = false
+_isnull(x::Nullable) = isnull(x)
+
+@doc """
+`dropnull(X::AbstractVector)`
+
+Return a vector containing only the non-null entries of `X`,
+unwrapping `Nullable` entries. A copy is always returned, even when
+`X` does not contain any null values.
 """ ->
-dropnull(X::NullableVector) = copy(X.values[!X.isnull]) # -> Vector{T}
+function dropnull(X::AbstractVector)                 # -> AbstractVector
+    Y = filter(x->!_isnull(x), X)
+    res = similar(Y)
+    for i in eachindex(Y, res)
+        res[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
+    end
+    res
+end
+function dropnull{T<:Nullable}(X::AbstractVector{T}) # -> AbstractVector
+    Y = filter(x->!_isnull(x), X)
+    res = similar(Y, eltype(T))
+    for i in eachindex(Y, res)
+        res[i] = Y[i].value
+    end
+    res
+end
+dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 
 @doc """
-`anynull(X::NullableArray)`
+`anynull(X)`
 
 Returns whether or not any entries of `X` are null.
 """ ->
-anynull(X::NullableArray) = any(X.isnull) # -> Bool
-
-# @doc """
-#
-# """ ->
-# NOTE: the following currently short-circuits.
-function anynull(A::AbstractArray) # -> Bool
-    for a in A
-        if isa(a, Nullable)
-            a.isnull && (return true)
-        end
-    end
-    return false
-end
-#
-# @doc """
-#
-# """ ->
-function anynull(xs::NTuple) # -> Bool
-    for x in xs
-        if isa(x, Nullable)
-            x.isnull && (return true)
-        end
-    end
-    return false
-end
+anynull(X::Any) = any(_isnull, X)           # -> Bool
+anynull(X::NullableArray) = any(X.isnull)   # -> Bool
 
 @doc """
-`allnull(X::NullableArray)`
+`allnull(X)`
 
 Returns whether or not all the entries in `X` are null.
 """ ->
-allnull(X::NullableArray) = all(X.isnull) # -> Bool
+allnull(X::Any) = all(_isnull, X)           # -> Bool
+allnull(X::NullableArray) = all(X.isnull)   # -> Bool
 
 @doc """
 `isnan(X::NullableArray)`

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -161,8 +161,18 @@ module TestPrimitives
 
 # ----- test dropnull --------------------------------------------------------#
 
+    # dropnull(X::NullableArray)
     z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
     @test dropnull(z) == [1, 2, 3, 5, 7]
+
+    # dropnull(X::AbstractArray)
+    A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
+            Nullable(), Nullable(7), Nullable()]
+    @test dropnull(A) == [1, 2, 3, 5, 7]
+
+    # dropnull(X::AbstractArray{<:Nullable})
+    B = convert(Vector{Nullable}, A)
+    @test dropnull(B) == [1, 2, 3, 5, 7]
 
 # ----- test anynull ---------------------------------------------------------#
 
@@ -197,9 +207,19 @@ module TestPrimitives
 
 # ----- test allnull ---------------------------------------------------------#
 
+    # allnull(X::NullableArray)
     @test allnull(z) == true
-    setindex!(z, 10, 1)
+    z[1] = 10
     @test allnull(z) == false
+
+    # anynull(X::AbstractArray{<:Nullable})
+    @test allnull(Nullable{Int}[Nullable(), Nullable()]) == true
+    @test allnull(Nullable{Int}[Nullable(1), Nullable()]) == false
+
+    # anynull(X::Any)
+    @test allnull(Any[Nullable(), Nullable()]) == true
+    @test allnull([1, 2]) == false
+    @test allnull(1:3) == false
 
 # ----- test Base.isnan ------------------------------------------------------#
 


### PR DESCRIPTION
Support for any AbstractArray is needed to write generic code supporting
e.g. Array{Nullable} and NullableCategoricalArray. Make the semantics
of dropnull() more explicit in the docs.

Simplify the implementation of anynull(). In dropnull(X::NullableVector),
remove the redundant copy(): indexing already makes a copy.

(Travis failure on master is unrelated.)
