### PR TITLE
Add isless(::Nullable, ::Nullable) -> Bool

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -201,6 +201,17 @@ module TestOperators
                 x = op(Nullable(), Nullable())
                 @test isa(x, Nullable{Union{}}) && isnull(x)
             end
+
+            # isless
+            @test isless(Nullable(u), Nullable(v)) === isless(u, v)
+
+            @test isless(Nullable(u), Nullable(v, true)) === true
+            @test isless(Nullable(u, true), Nullable(v)) === false
+            @test isless(Nullable(u, true), Nullable(v, true)) === false
+
+            @test isless(Nullable(u), Nullable()) === true
+            @test isless(Nullable(), Nullable(v)) === false
+            @test isless(Nullable(), Nullable()) === false
         end
     end
 end


### PR DESCRIPTION
This method complements isequal(), which also returns a Bool, as it
must implement a total order. NULLs are treated like NaNs: they are
never isless() than any other value, including other NULLs. They are
therefore always sorted last.

(Travis failure on master is unrelated.)
