### PR TITLE
Avoid a DomainError if v2 ever happens to be typemin of a signed inte…

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -78,7 +78,7 @@ module TestOperators
         v1 = one(T)
         v2 = T <: Union{BigInt, BigFloat} ? T(rand(Int128)) : rand(T)
 
-        abs(v2) > 5 && (v2 = T(5)) # Work around JuliaLang/julia#16989
+        (v2 > 5 || v2 < -5) && (v2 = T(5)) # Work around JuliaLang/julia#16989
 
         # safe unary operators
         for op in (+, -, ~, abs, abs2, cbrt)


### PR DESCRIPTION
…ger type

e.g. `abs(Int8(-128)) == -128`

ref https://github.com/JuliaLang/julia/pull/18478#issuecomment-246877142 - I'm not sure why changing `VERSION` in Julia would result in different random numbers here despite the `srand` in this file. Any ideas why that would happen?
