### PR TITLE
Fix operators test on Julia 0.6

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -160,10 +160,10 @@ module TestOperators
 
             # unsafe binary operators
             # ^
-            if S <: Integer && T <: Integer && u != 0
-                @test_throws DomainError Nullable(u)^Nullable(ensure_neg(one(v)))
+            if S <: Integer && T <: Integer && u != 0 && u != 1 && v != 0
+                @test_throws DomainError Nullable(u)^Nullable(ensure_neg(v))
             end
-            @test isequal(Nullable(u)^Nullable(2*one(T)), Nullable(u^(2*one(T))))
+            @test isequal(Nullable(u)^Nullable(one(T)+one(T)), Nullable(u^(one(T)+one(T))))
             R = Base.promote_op(^, S, T)
             x = Nullable(u, true)^Nullable(-abs(v), true)
             @test isnull(x) && eltype(x) === R


### PR DESCRIPTION
0^-1 no longer throws an exception there. Also remove a multiplication to
ensure we preserve types instead of promoting to Int64.

We should probably tag a release after this one so that the package's tests still pass on the coming 0.4.7.
