### PR TITLE
@inline isless(::Nullable, ::Nullable)

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -133,7 +133,7 @@ for op in (:+, :-, :*, :/, :%, :÷, :&, :|, :^, :<<, :>>, :(>>>),
 end
 
 if !method_exists(isless, (Nullable, Nullable))
-    function isless{S,T}(x::Nullable{S}, y::Nullable{T})
+    @inline function isless{S,T}(x::Nullable{S}, y::Nullable{T})
         # NULL values are sorted last
         if null_safe_op(@functorize(isless), S, T)
             (!x.isnull & y.isnull) |


### PR DESCRIPTION
This enables SIMD for basic types when null_safe_op() is true. Inlining of
the isequal() call on values still depends on the element type.

The same change has been applied to Base on master, this allows keeping
functions in sync.
