### PR TITLE
implemented NullableArray{T,N}(dims...)

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -34,6 +34,7 @@ end
 
 @compat (::Type{NullableArray{T}}){T}(dims::Dims) = NullableArray(T, dims)
 @compat (::Type{NullableArray{T}}){T}(dims::Int...) = NullableArray(T, dims)
+@compat (::Type{NullableArray{T,N}}){T,N}(dims::Vararg{Int,N}) = NullableArray(T, dims)
 
 # The following method constructs a NullableArray from an Array{Any} argument
 # 'A' that contains some placeholder of type 'T' for null values.

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -34,14 +34,13 @@ end
 
 @compat (::Type{NullableArray{T}}){T}(dims::Dims) = NullableArray(T, dims)
 @compat (::Type{NullableArray{T}}){T}(dims::Int...) = NullableArray(T, dims)
-if VERSION >= v"0.5.0-dev"
-    (::Type{NullableArray{T,N}}){T,N}(dims::Vararg{Int,N}) = NullableArray(T, dims)
+if VERSION >= v"0.5.0-"
+    @compat (::Type{NullableArray{T,N}}){T,N}(dims::Vararg{Int,N}) = NullableArray(T, dims)
 else
-    @compat (::Type{NullableArray{T,1}}){T,N}(x1) = NullableArray(T, x1)
-    @compat (::Type{NullableArray{T,2}}){T,N}(x1, x2) = NullableArray(T, x1, x2)
-    @compat (::Type{NullableArray{T,3}}){T,N}(x1, x2, x3) = NullableArray(T, x1, x2, x3)
-    @compat (::Type{NullableArray{T,3}}){T,N}(x1, x2, x3, x4) = NullableArray(T, x1, x2, x3, x4)
-    @compat (::Type{NullableArray{T,3}}){T,N}(x1, x2, x3, x4, x5) = NullableArray(T, x1, x2, x3, x4, x5)
+  function Base.convert{T,N}(::Type{NullableArray{T,N}}, dims::Int...)
+      length(dims) == N || throw(ArgumentError("Wrong number of arguments. Expected $N, got $(length(dims))."))
+      NullableArray(T, dims)
+  end
 end
 
 # The following method constructs a NullableArray from an Array{Any} argument

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -37,10 +37,10 @@ end
 if VERSION >= v"0.5.0-"
     @compat (::Type{NullableArray{T,N}}){T,N}(dims::Vararg{Int,N}) = NullableArray(T, dims)
 else
-  function Base.convert{T,N}(::Type{NullableArray{T,N}}, dims::Int...)
-      length(dims) == N || throw(ArgumentError("Wrong number of arguments. Expected $N, got $(length(dims))."))
-      NullableArray(T, dims)
-  end
+    function Base.convert{T,N}(::Type{NullableArray{T,N}}, dims::Int...)
+        length(dims) == N || throw(ArgumentError("Wrong number of arguments. Expected $N, got $(length(dims))."))
+        NullableArray(T, dims)
+    end
 end
 
 # The following method constructs a NullableArray from an Array{Any} argument

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -34,7 +34,15 @@ end
 
 @compat (::Type{NullableArray{T}}){T}(dims::Dims) = NullableArray(T, dims)
 @compat (::Type{NullableArray{T}}){T}(dims::Int...) = NullableArray(T, dims)
-@compat (::Type{NullableArray{T,N}}){T,N}(dims::Vararg{Int,N}) = NullableArray(T, dims)
+if VERSION >= v"0.5.0-dev"
+    (::Type{NullableArray{T,N}}){T,N}(dims::Vararg{Int,N}) = NullableArray(T, dims)
+else
+    @compat (::Type{NullableArray{T,1}}){T,N}(x1) = NullableArray(T, x1)
+    @compat (::Type{NullableArray{T,2}}){T,N}(x1, x2) = NullableArray(T, x1, x2)
+    @compat (::Type{NullableArray{T,3}}){T,N}(x1, x2, x3) = NullableArray(T, x1, x2, x3)
+    @compat (::Type{NullableArray{T,3}}){T,N}(x1, x2, x3, x4) = NullableArray(T, x1, x2, x3, x4)
+    @compat (::Type{NullableArray{T,3}}){T,N}(x1, x2, x3, x4, x5) = NullableArray(T, x1, x2, x3, x4, x5)
+end
 
 # The following method constructs a NullableArray from an Array{Any} argument
 # 'A' that contains some placeholder of type 'T' for null values.

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -75,6 +75,19 @@ module TestConstructors
         @test isequal(X3, NullableArray(Array{Int}(dims...), fill(true, dims...)))
     end
 
+    # test NullableArray{T}(dims::Int...)
+    d1, d2 = rand(1:100), rand(1:100)
+    X1 = NullableArray{Int,1}(d1)
+    X2 = NullableArray{Int,2}(d1, d2)
+    @test isequal(X1, NullableArray(Array{Int,1}(d1), fill(true, d1)))
+    @test isequal(X2, NullableArray(Array{Int,2}(d1, d2), fill(true, d1, d2)))
+    for i in 1:5
+        m = rand(3:5)
+        dims = [ rand(1:5) for i in 1:m ]
+        X3 = NullableArray{Int,length(dims)}(dims...)
+        @test isequal(X3, NullableArray(Array{Int}(dims...), fill(true, dims...)))
+    end
+
     # test (A::AbstractArray, ::Type{T}, ::Type{U}) constructor
     z = NullableArray([1, nothing, 2, nothing, 3], Int, Void)
     @test isa(z, NullableVector{Int})


### PR DESCRIPTION
This is needed for instance when I have a NullableArray `A` of some type and want to create another one of the same type with only nulls in it like so: `typeof(A)(size(A)...)`
