### PR TITLE
[RFC/WIP] Few additional methods

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -77,18 +77,18 @@ to store `v` at `I`.
 end
 
 # return the value of non-null X element wrapped in Nullable
-function unsafe_getindex_notnull(X::NullableArray, I::Int...)
+@inline function unsafe_getindex_notnull(X::NullableArray, I::Int...)
     return Nullable(getindex(X.values, I...))
 end
-function unsafe_getindex_notnull{T}(X::AbstractArray{Nullable{T}}, I::Int...)
+@inline function unsafe_getindex_notnull{T}(X::AbstractArray{Nullable{T}}, I::Int...)
     return getindex(X, I...)
 end
 
 # return the value of non-null X element
-function unsafe_getvalue_notnull(X::NullableArray, I::Int...)
+@inline function unsafe_getvalue_notnull(X::NullableArray, I::Int...)
     return getindex(X.values, I...)
 end
-function unsafe_getvalue_notnull{T}(X::AbstractArray{Nullable{T}}, I::Int...)
+@inline function unsafe_getvalue_notnull{T}(X::AbstractArray{Nullable{T}}, I::Int...)
     return get(getindex(X, I...))
 end
 
@@ -142,6 +142,6 @@ end
 
 This is a convenience method to set the entry of `X` at index `I` to be null
 """
-function nullify!(X::NullableArray, I...)
+@inline function nullify!(X::NullableArray, I...)
     setindex!(X, Nullable{eltype(X)}(), I...)
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -76,10 +76,12 @@ to store `v` at `I`.
     return v
 end
 
+# return the value of non-null X element wrapped in Nullable
 function unsafe_getindex_notnull(X::NullableArray, I::Int...)
     return Nullable(getindex(X.values, I...))
 end
 
+# return the value of non-null X element
 function unsafe_getvalue_notnull(X::NullableArray, I::Int...)
     return getindex(X.values, I...)
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -80,10 +80,16 @@ end
 function unsafe_getindex_notnull(X::NullableArray, I::Int...)
     return Nullable(getindex(X.values, I...))
 end
+function unsafe_getindex_notnull{T}(X::AbstractArray{Nullable{T}}, I::Int...)
+    return getindex(X, I...)
+end
 
 # return the value of non-null X element
 function unsafe_getvalue_notnull(X::NullableArray, I::Int...)
     return getindex(X.values, I...)
+end
+function unsafe_getvalue_notnull{T}(X::AbstractArray{Nullable{T}}, I::Int...)
+    return get(getindex(X, I...))
 end
 
 if VERSION >= v"0.5.0-dev+4697"

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -109,17 +109,17 @@ else
      end
 
     function Base.checkbounds(::Type{Bool}, sz::Int, I::NullableVector{Bool})
-         any(isnull, I) && throw(NullException())
+        any(isnull, I) && throw(NullException())
         length(I) == sz
-     end
+    end
 
     function Base.checkbounds{T<:Real}(::Type{Bool}, sz::Int, I::NullableArray{T})
         inbounds = true
-         any(isnull, I) && throw(NullException())
-         for i in 1:length(I)
+        any(isnull, I) && throw(NullException())
+        for i in 1:length(I)
              @inbounds v = unsafe_getvalue_notnull(I, i)
             inbounds &= checkbounds(Bool, sz, v)
-         end
+        end
         return inbounds
      end
 end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,6 +1,6 @@
-Base.isnull(X::NullableArray, I::Int...) = X.isnull[I...]
-Base.isnull{T}(X::AbstractArray{Nullable{T}}, I::Int...) = isnull(X[I...]) # fallback method
-Base.values(X::NullableArray, I::Int...) = X.values[I...]
+@inline Base.isnull(X::NullableArray, I::Int...) = X.isnull[I...]
+@inline Base.isnull{T}(X::AbstractArray{Nullable{T}}, I::Int...) = isnull(X[I...]) # fallback method
+@inline Base.values(X::NullableArray, I::Int...) = X.values[I...]
 
 """
     size(X::NullableArray, [d::Real])

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -1,4 +1,5 @@
 Base.isnull(X::NullableArray, I::Int...) = X.isnull[I...]
+Base.isnull{T}(X::AbstractArray{Nullable{T}}, I::Int...) = isnull(X[I...]) # fallback method
 Base.values(X::NullableArray, I::Int...) = X.values[I...]
 
 """

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -75,9 +75,9 @@ function _mapreduce_skipnull{T}(f, op, X::NullableArray{T}, missingdata::Bool)
     !missingdata && return Nullable(Base.mapreduce_impl(f, op, X.values, 1, n))
 
     nnull = countnz(X.isnull)
-    nnull == n && return Base.mr_empty(f, op, T)
-    nnull == n - 1 && return Nullable(Base.r_promote(op, f(X.values[findfirst(X.isnull, false)])))
-    # nnull == 0 && return Base.mapreduce_impl(f, op, X, 1, n)
+    nnull == n && return Nullable(Base.mr_empty(f, op, T))
+    @inbounds (nnull == n - 1 && return Nullable(Base.r_promote(op, f(X.values[findfirst(X.isnull, false)]))))
+    #nnull == 0 && return Nullable(Base.mapreduce_impl(f, op, X.values, 1, n)) # there is missing data, so nnull>0
 
     return mapreduce_impl_skipnull(f, op, X)
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -136,7 +136,7 @@ function Base.mapreduce(f, op, X::NullableArray; skipnull::Bool = false)
 end
 
 """
-    mapreduce(f, op::Function, X::NullableArray; [skipnull::Bool=false])
+    reduce(op::Function, X::NullableArray; [skipnull::Bool=false])
 
 Reduce `X`under the operation `op`. One can set the behavior of this method to
 skip the null entries of `X` by setting the keyword argument `skipnull` equal

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -76,7 +76,7 @@ function _mapreduce_skipnull{T}(f, op, X::NullableArray{T}, missingdata::Bool)
 
     nnull = countnz(X.isnull)
     nnull == n && return Base.mr_empty(f, op, T)
-    nnull == n - 1 && return Base.r_promote(op, f(X.values[findnext(x -> x == false), X, 1]))
+    nnull == n - 1 && return Nullable(Base.r_promote(op, f(X.values[findfirst(X.isnull, false)])))
     # nnull == 0 && return Base.mapreduce_impl(f, op, X, 1, n)
 
     return mapreduce_impl_skipnull(f, op, X)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,22 +1,29 @@
 module TestReduce
     using NullableArrays
     using Base.Test
+    import Base.mr_empty
 
-    srand(1)
     f(x) = 5 * x
     f{T<:Number}(x::Nullable{T}) = ifelse(isnull(x), Nullable{typeof(5 * x.value)}(),
                                                      Nullable(5 * x.value))
+    # FIXME should Base/NullableArrays handle this automatically?
+    Base.mr_empty(::typeof(f), op::typeof(+), T) = Base.r_promote(op, zero(T)::T)
+    Base.mr_empty(::typeof(f), op::typeof(*), T) = Base.r_promote(op, one(T)::T)
 
-    for N in (10, 2050)
+    srand(1)
+    for (N, allnull) in ((2, true), (2, false), (10, false), (2050, false))
         A = rand(N)
-        M = rand(Bool, N)
-        i = rand(1:N)
-        M[i] = true
-        j = rand(1:N)
-        while j == i
-            j = rand(1:N)
+        if allnull
+            M = fill(true, N)
+        else
+            M = rand(Bool, N)
+            i = rand(1:N)
+            # should have at least one null and at least one non-null
+            M[i] = true
+            j = rand(1:(N-1))
+            (j == i) && (j += 1)
+            M[j] = false
         end
-        M[j] = false
         X = NullableArray(A)
         Y = NullableArray(A, M)
         B = A[find(x->!x, M)]
@@ -42,13 +49,22 @@ module TestReduce
             @test isequal(method(X), Nullable(method(A)))
             @test isequal(method(f, X), Nullable(method(f, A)))
             @test isequal(method(Y), Nullable{Float64}())
-            v = method(Y, skipnull=true)
-            @test v.value ≈ method(B)
-            @test !isnull(v)
             @test isequal(method(f, Y), Nullable{Float64}())
-            v = method(f, Y, skipnull=true)
-            @test v.value ≈ method(f, B)
-            @test !isnull(v)
+            # test skipnull=true
+            if !allnull || method ∈ [sum, prod]
+                # reduce
+                v_r = method(Y, skipnull=true)
+                @test v_r.value ≈ method(B)
+                @test !isnull(v_r)
+                # mapreduce
+                v_mr = method(f, Y, skipnull=true)
+                @test v_mr.value ≈ method(f, B)
+                @test !isnull(v_mr)
+            else
+                # reduction over empty collection not defined for these methods
+                @test_throws ArgumentError method(Y, skipnull=true)
+                @test_throws ArgumentError method(f, Y, skipnull=true)
+            end
         end
 
         @test isequal(extrema(X), (Nullable(minimum(A)), Nullable(maximum(A))))


### PR DESCRIPTION
Some methods that I introduced, while rebasing JuliaStats/DataFrames.jl#850
- `isnull(A::NullableArray)` to get the boolean array of `A` nulls
- `unsafe_isnull(A::NullableArray, i::Int...)` to check for nulls without checking the validity of the index
- `AbstractNullableArray{T, N}` typealias of `AbstractArray{Nullable{T}, N}` (however `AbstractNullableArray` (without params) is not considered by Julia more specific than `AbstractArray`, I don't know if it's a known feature/bug)
-  `isless{T,S}(a::Nullable{T}, b::S)` to compare nullables vs nonnullables (nonnullable is always less)
