### PR TITLE
Fix failure on Windows

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -66,6 +66,9 @@ if VERSION >= v"0.5.0-dev"
     null_safe_op{T<:SafeInts}(::typeof(~), ::Type{T}) = true
     null_safe_op{T<:SafeTypes}(::typeof(cbrt), ::Type{T}) = true
     null_safe_op(::typeof(!), ::Type{Bool}) = true
+
+    # Temporary workaround until JuliaLang/julia#18803
+    null_safe_op(::typeof(cbrt), ::Type{Float16}) = false
 end
 
 for op in (:+, :-, :!, :~, :abs, :abs2, :sqrt, :cbrt)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -46,6 +46,8 @@ module TestOperators
             # safe unary operators
             for op in (+, -, ~, abs, abs2, cbrt)
                 S <: AbstractFloat && op == (~) && continue
+                # Temporary workaround until JuliaLang/julia#18803
+                S === Float16 && op == cbrt && continue
 
                 @test op(Nullable(u0)) === Nullable(op(u0))
                 @test op(Nullable(u1)) === Nullable(op(u1))


### PR DESCRIPTION
The tests failure on Windows wasn't actually Windows-specific at all. It happens when calling `cbrt(Nullable{Float16}())` and the underlying value happens to be negative. Should be fixed in Julia (https://github.com/JuliaLang/julia/pull/18803), but in the meantime disable the fast path.

Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/154.
