### PR TITLE
Fix constructor/convert for Array{Nullable} without element type

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -111,8 +111,8 @@ function Base.convert{T, N}(::Type{NullableArray},
 end
 
 #----- Conversion from arrays of Nullables -----------------------------------#
-function Base.convert{S, T, N}(::Type{NullableArray{T, N}},
-                               A::AbstractArray{Nullable{S}, N}) # -> NullableArray{T, N}
+function Base.convert{S<:Nullable, T, N}(::Type{NullableArray{T, N}},
+                                         A::AbstractArray{S, N}) # -> NullableArray{T, N}
    out = NullableArray{T, N}(Array(T, size(A)), Array(Bool, size(A)))
    for i = 1:length(A)
        if !(out.isnull[i] = isnull(A[i]))
@@ -133,6 +133,11 @@ end
 function Base.convert{T, N}(::Type{NullableArray},
                             A::AbstractArray{Nullable{T}, N}) # -> NullableArray{T, N}
     convert(NullableArray{T, N}, A)
+end
+
+function Base.convert{N}(::Type{NullableArray},
+                         A::AbstractArray{Nullable, N}) # -> NullableArray{Any, N}
+    convert(NullableArray{Any, N}, A)
 end
 
 function Base.convert{S, T, N}(::Type{NullableArray{T, N}},

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -124,6 +124,15 @@ module TestConstructors
         @test isequal(convert(NullableArray{Float64,1}, a), NullableArray{Float64,1}([1.0,2.0,3.0,4.0],miss))
     end
 
+    # test conversion from Array{Nullable} without element type (issue #145)
+    @test isa(NullableArray(Nullable[Nullable(1), Nullable(2), Nullable(3), Nullable()]), NullableArray{Any})
+    @test isa(NullableArray{Int}(Nullable[Nullable(1), Nullable(2), Nullable(3), Nullable()]), NullableArray{Int})
+    @test isa(NullableArray{Float64}(Nullable[Nullable(1), Nullable(2), Nullable(3), Nullable()]), NullableArray{Float64})
+
+    @test isa(convert(NullableArray, Nullable[Nullable(1), Nullable(2), Nullable(3), Nullable()]), NullableArray{Any})
+    @test isa(convert(NullableArray{Int}, Nullable[Nullable(1), Nullable(2), Nullable(3), Nullable()]), NullableArray{Int})
+    @test isa(convert(NullableArray{Float64}, Nullable[Nullable(1), Nullable(2), Nullable(3), Nullable()]), NullableArray{Float64})
+
     # converting a NullableArray to unqualified type NullableArray should be no-op
     m = rand(10:100)
     A = rand(m)


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/145.
