### PR TITLE
Fix operators test

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -88,6 +88,10 @@ module TestOperators
         v1 = one(T)
         v2 = T <: Union{BigInt, BigFloat} ? T(rand(Int128)) : rand(T)
 
+        # abs(typemin(x)) is negative (bad luck)
+        abs(u2) < 0 && (u2 = S(u2 + 1))
+        abs(v2) < 0 && (v2 = T(v2 + 1))
+
         (v2 > 5 || v2 < -5) && (v2 = T(5)) # Work around JuliaLang/julia#16989
 
         # safe unary operators


### PR DESCRIPTION
Due to a very bad luck, the random number was Int8(-128), for which abs()
is negative and makes the test fail. Ensure this cannot happen.