### PR TITLE
WIP: allow value array to be any AbstractArray

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -83,8 +83,7 @@ end
 #
 function NullableArray{T}(A::AbstractArray,
                              ::Type{T},
-                             na::Any;
-                             conversion::Base.Callable=Base.convert) # -> NullableArray{T, N}
+                             na::Any) # -> NullableArray{T, N}
     res = NullableArray(T, size(A))
     for i in 1:length(A)
         if !isequal(A[i], na)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -105,7 +105,7 @@ end
 #----- Conversion from arrays (of non-Nullables) -----------------------------#
 function Base.convert{S, T, N}(::Type{NullableArray{T, N}},
                                A::AbstractArray{S, N}) # -> NullableArray{T, N}
-    NullableArray{T, N}(convert(Array{T, N}, A), fill(false, size(A)))
+    NullableArray{T, N}(convert(AbstractArray{T, N}, A), fill(false, size(A)))
 end
 
 function Base.convert{S, T, N}(::Type{NullableArray{T}},
@@ -150,5 +150,5 @@ end
 
 function Base.convert{S, T, N}(::Type{NullableArray{T, N}},
                                A::NullableArray{S, N}) # -> NullableArray{T, N}
-    NullableArray(convert(Array{T, N}, A.values), A.isnull)
+    NullableArray(convert(AbstractArray{T, N}, A.values), A.isnull)
 end

--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -19,7 +19,7 @@ It allows users to easily define operations on arrays with null values by
 reusing operations that only work on arrays without any null values.
 """
 immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
-    values::Array{T, N}
+    values::AbstractArray{T, N}
     isnull::Array{Bool, N}
     # extra field for potentially holding a reference to a parent memory block
     # (think mmapped file, for example) that `values` is actually derived from

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -145,8 +145,8 @@ module TestNullableVector
     #--- test Base.deleteat!
 
     # Base.deleteat!(X::NullableArray, inds)
-    X = NullableArray(1:10)
-    @test isequal(deleteat!(X, 1), NullableArray(2:10))
+    X = NullableArray([1:10;])
+    @test isequal(deleteat!(X, 1), NullableArray([2:10;]))
 
     #--- test Base.append!
 
@@ -154,7 +154,7 @@ module TestNullableVector
     @test isequal(append!(X, [11, 12]),
                   NullableArray(2:12))
     @test isequal(append!(X, [Nullable(13), Nullable(14)]),
-                  NullableArray(2:14))
+                  NullableArray([2:14;]))
     @test isequal(append!(X, [Nullable(15), Nullable{Int}()]),
                   NullableArray(Nullable{Int}[2:15..., Nullable()]))
 
@@ -162,11 +162,11 @@ module TestNullableVector
 
     # Base.prepend!(X::NullableVector, items::AbstractVector)
 
-    X = NullableArray(3:12)
+    X = NullableArray([3:12;])
     @test isequal(prepend!(X, [1, 2]),
-                  NullableArray(1:12))
+                  NullableArray([1:12;]))
     @test isequal(prepend!(X, [Nullable(-1), Nullable(0)]),
-                  NullableArray(-1:12))
+                  NullableArray([-1:12;]))
     @test isequal(prepend!(X, [Nullable{Int}(), Nullable(-2)]),
                   NullableArray(Nullable{Int}[Nullable(), -2:12...]))
 
@@ -178,13 +178,13 @@ module TestNullableVector
     #--- test padnull!
 
     # padnull!{T}(X::NullableVector{T}, front::Integer, back::Integer)
-    X = NullableArray(1:5)
+    X = NullableArray([1:5;])
     padnull!(X, 2, 3)
     @test length(X.values) == 10
     @test X.isnull == vcat(true, true, fill(false, 5), true, true, true)
 
     # padnull(X::NullableVector, front::Integer, back::Integer)
-    X = NullableArray(1:5)
+    X = NullableArray([1:5;])
     Y = padnull(X, 2, 3)
     @test length(Y.values) == 10
     @test Y.isnull == vcat(true, true, fill(false, 5), true, true, true)


### PR DESCRIPTION
This makes possible construction of NullableArray of StructOfArrays, or other [funky arrays](https://github.com/JuliaData/CSV.jl/blob/speedups/src/textparser/lib/substringarray.jl#L6-L9) which solve orthogonal problems.

The following fails with this patch applied:

```julia
julia> isequal(NullableArray(Union{},1), NullableArray(Float64,1))
ERROR: indexing not defined for NullableArrays.NullableArray{Union{},1}
 in _getindex(::Base.LinearFast, ::NullableArrays.NullableArray{Union{},1}, ::Int64) at ./abstractarray.jl:763
 in next at ./iterator.jl:98 [inlined]
 in isequal(::NullableArrays.NullableArray{Union{},1}, ::NullableArrays.NullableArray{Float64,1}) at ./abstractarray.jl:1385
```
Stepping through this with Gallium doesn't fail with this error, it instead succeeds in returning `true`! cc @keno