### PR TITLE
Fix v0.6 deprecation warnings

### DIFF
--- a/perf/broadcast.jl
+++ b/perf/broadcast.jl
@@ -10,7 +10,7 @@ B1 = rand(Bool, 5_000_000)
 B2 = rand(Bool, 5_000_000, 2)
 C1 = rand(1:10, 5_000_000)
 C2 = rand(Int, 5_000_000, 2)
-L = Array(Float64, 5_000_000, 2)
+L = Array{Float64}(5_000_000, 2)
 
 U = NullableArray(Float64, 5_000_000, 2)
 X1 = NullableArray(A1)

--- a/perf/map.jl
+++ b/perf/map.jl
@@ -4,7 +4,7 @@ srand(1)
 N = 5_000_000
 A = rand(N)
 B = rand(Bool, N)
-C = Array(Float64, N)
+C = Array{Float64}(N)
 
 
 X = NullableArray(A)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -22,7 +22,7 @@ end
 # `NullableArray` a null value by default.
 # """
 function NullableArray{T}(::Type{T}, dims::Dims) # -> NullableArray{T, N}
-    return NullableArray(Array(T, dims), fill(true, dims))
+    return NullableArray(Array{T}(dims), fill(true, dims))
 end
 
 # Constructs an empty NullableArray of type parameter T and number of dimensions
@@ -121,7 +121,7 @@ end
 #----- Conversion from arrays of Nullables -----------------------------------#
 function Base.convert{S<:Nullable, T, N}(::Type{NullableArray{T, N}},
                                          A::AbstractArray{S, N}) # -> NullableArray{T, N}
-   out = NullableArray{T, N}(Array(T, size(A)), Array(Bool, size(A)))
+   out = NullableArray{T, N}(Array{T}(size(A)), Array{Bool}(size(A)))
    for i = 1:length(A)
        if !(out.isnull[i] = isnull(A[i]))
            out.values[i] = A[i].value

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -138,7 +138,7 @@ function Base.find(X::NullableArray{Bool}) # -> Array{Int}
     @inbounds for (i, isnull) in enumerate(X.isnull)
         ntrue += !isnull && X.values[i]
     end
-    res = Array(Int, ntrue)
+    res = Array{Int}(ntrue)
     ind = 1
     @inbounds for (i, isnull) in enumerate(X.isnull)
         if !isnull && X.values[i]
@@ -215,7 +215,7 @@ null entries of `X` will be reflected by null entries of the resultant
 `NullableArray`.
 """
 function Base.isfinite(X::NullableArray) # -> NullableArray{Bool}
-    res = Array(Bool, size(X))
+    res = Array{Bool}(size(X))
     for i in eachindex(X)
         if !X.isnull[i]
             res[i] = isfinite(X.values[i])
@@ -272,7 +272,7 @@ function Base.convert{S, T, N}(::Type{Array{S, N}},
                                X::NullableArray{T, N},
                                replacement::Any) # -> Array{S, N}
     replacementS = convert(S, replacement)
-    res = Array(S, size(X))
+    res = Array{S}(size(X))
     for i in 1:length(X)
         if X.isnull[i]
             res[i] = replacementS

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -9,11 +9,11 @@ module TestBroadcast
     dims = [ rand(2:5) for i in 1:n]
     A2 = rand(10, dims...)
     M2 = rand(Bool, 10, dims...)
-    C2 = Array(Float64, 10, dims...)
+    C2 = Array{Float64}(10, dims...)
     i = rand(2:5)
     A3 = rand(10, [dims; i]...)
     M3 = rand(Bool, 10, [dims; i]...)
-    C3 = Array(Float64, 10, [dims; i]...)
+    C3 = Array{Float64}(10, [dims; i]...)
 
     m1 = broadcast((x,y)->x, M1, M2)
     m2 = broadcast((x,y)->x, M2, M3)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -12,7 +12,7 @@ module TestConstructors
     m = [1 2; 3 4]
     dm = NullableArray(m, fill(false, size(m)))
 
-    t = Array(Int, 2, 2, 2)
+    t = Array{Int}(2, 2, 2)
     t[1:2, 1:2, 1:2] = 1
 
     dt = NullableArray(t, fill(false, size(t)))

--- a/test/map.jl
+++ b/test/map.jl
@@ -20,7 +20,7 @@ module TestMap
         push!(Ys, NullableArray(As[i], Ms[i]))
     end
 
-    C = Array(Float64, dims...)
+    C = Array{Float64}(dims...)
     Z = NullableArray(Float64, dims...)
 
     R = map(|, Ms...)


### PR DESCRIPTION
Does nothing to fix the failures on 0.6 but at least gets the `Array` constructor-related deprecation warnings out of the way.