### PR TITLE
Add extrema(::NullableArray)

### DIFF
--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -51,6 +51,15 @@ module TestReduce
             @test !isnull(v)
         end
 
+        @test isequal(extrema(X), (Nullable(minimum(A)), Nullable(maximum(A))))
+        @test isequal(extrema(Y), (Nullable{Float64}(), Nullable{Float64}()))
+        v1 = extrema(Y, skipnull=true)
+        v2 = extrema(B)
+        @test v1[1].value == v2[1]
+        @test !isnull(v1[1])
+        @test v1[2].value == v2[2]
+        @test !isnull(v1[2])
+
         H = rand(Bool, N)
         G = H[find(x->!x, M)]
         U = NullableArray(H)


### PR DESCRIPTION
To complement existing maximum() and minimum(). For now the two-argument
version (taking a dimension) is not supported, just like for these two
functions.

Useful to implement `cut` in CategoricalArrays.