### PR TITLE
Fix broadcast() and map() when passed arrays with different eltypes

### DIFF
--- a/src/lift.jl
+++ b/src/lift.jl
@@ -13,7 +13,8 @@ Lift function `f`, passing it arguments `xs...`, using standard lifting semantic
 for a function call `f(xs...)`, return null if any `x` in `xs` is null; otherwise,
 return `f` applied to values of `xs`.
 """
-@inline @generated function lift{F, N, T}(f::F, xs::NTuple{N, T})
+@inline @generated function lift{F}(f::F, xs::Tuple)
+    N = nfields(xs)
     args = (:(unsafe_get(xs[$i])) for i in 1:N)
     checknull = (:(!isnull(xs[$i])) for i in 1:N)
     if null_safe_op(f.instance, map(eltype_nullable, xs.parameters)...)

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -3,7 +3,7 @@ module TestBroadcast
     using Base.Test
     using Compat
 
-    A1 = rand(10)
+    A1 = rand(Int, 10)
     M1 = rand(Bool, 10)
     n = rand(2:5)
     dims = [ rand(2:5) for i in 1:n]
@@ -32,9 +32,9 @@ module TestBroadcast
     Z3 = NullableArray(Float64, 10, [dims; i]...)
 
     f() = 5
-    f(x::Float64) = 5 * x
-    f(x::Float64, y::Float64) = x * y
-    f(x::Float64, y::Float64, z::Float64) = x * y * z
+    f(x::Real) = 5 * x
+    f(x::Real, y::Real) = x * y
+    f(x::Real, y::Real, z::Real) = x * y * z
 
     for (dests, arrays, nullablearrays, mask) in
         ( ((C2, Z2), (A1, A2), (U1, U2), ()),

--- a/test/map.jl
+++ b/test/map.jl
@@ -6,15 +6,16 @@ module TestMap
     # dimension i for i=1:N
     N = rand(2:5)
     dims = Int[ rand(3:8) for i in 1:N ]
-    m = rand(3:5)
-    As = [ rand(dims...) for i in 1:m ]
+    m = rand(4:6)
+    n = rand(1:3)
+    As = Array[ [rand(dims...) for i in 1:n] ; [rand(Int, dims...) for i in n+1:m] ]
 
     Ms = [ rand(Bool, dims...) for i in 1:m ]
-    Xs = Array{NullableArray{Float64, N}, 1}()
+    Xs = Array{NullableArray, 1}()
     for i in 1:m
         push!(Xs, NullableArray(As[i]))
     end
-    Ys = Array{NullableArray{Float64, N}, 1}()
+    Ys = Array{NullableArray, 1}()
     for i in 1:m
         push!(Ys, NullableArray(As[i], Ms[i]))
     end


### PR DESCRIPTION
The explicit T type parameter to lift() forced input values to be of the
same type. Turns out it is not needed to force specialization.
Also add tests for this.

Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/174