### PR TITLE
Fix broadcast() and map() with constructors

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,4 +1,3 @@
-using Base: _default_eltype
 using Compat
 
 if VERSION >= v"0.6.0-dev.693"
@@ -10,6 +9,8 @@ else
 end
 
 if VERSION < v"0.6.0-dev" # Old approach needed for inference to work
+    using Base: _default_eltype
+
     ftype(f, A) = typeof(f)
     ftype(f, A...) = typeof(a -> f(a...))
     ftype(T::DataType, A) = Type{T}
@@ -20,12 +21,12 @@ if VERSION < v"0.6.0-dev" # Old approach needed for inference to work
     else
         using Base: Zip2
     end
-    ziptype(A) = Tuple{eltype(A)}
-    ziptype(A, B) = Zip2{Tuple{eltype(A)}, Tuple{eltype(B)}}
+    ziptype(A) = Tuple{eltype(eltype(A))}
+    ziptype(A, B) = Zip2{Tuple{eltype(eltype(A))}, Tuple{eltype(eltype(B))}}
     @inline ziptype(A, B, C, D...) = Zip{Tuple{eltype(A)}, ziptype(B, C, D...)}
 
     nullable_broadcast_eltype(f, As...) =
-        eltype(_default_eltype(Base.Generator{ziptype(As...), ftype(f, As...)}))
+        _default_eltype(Base.Generator{ziptype(As...), ftype(f, As...)})
 else
     Base.@pure nullable_eltypestuple(a) = Tuple{eltype(eltype(a))}
     Base.@pure nullable_eltypestuple(T::Type) = Tuple{Type{eltype(T)}}

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -7,7 +7,7 @@ eltypes(x) = Tuple{eltype_nullable(x)}
 eltypes(x, xs...) = Tuple{eltype_nullable(x), eltypes(xs...).parameters...}
 
 """
-  lift(f, xs...)
+    lift(f, xs...)
 
 Lift function `f`, passing it arguments `xs...`, using standard lifting semantics:
 for a function call `f(xs...)`, return null if any `x` in `xs` is null; otherwise,
@@ -17,19 +17,35 @@ return `f` applied to values of `xs`.
     N = nfields(xs)
     args = (:(unsafe_get(xs[$i])) for i in 1:N)
     checknull = (:(!isnull(xs[$i])) for i in 1:N)
-    if null_safe_op(f.instance, map(eltype_nullable, xs.parameters)...)
+    if isdefined(f, :instance) && null_safe_op(f.instance, map(eltype_nullable, xs.parameters)...)
         return quote
             val = f($(args...))
             nonull = (&)($(checknull...))
             @compat Nullable(val, nonull)
         end
-    else
+    elseif VERSION >= v"0.6.0-dev"
       return quote
           U = Core.Inference.return_type(f, eltypes(xs...))
           if (&)($(checknull...))
               return Nullable(f($(args...)))
           else
               return isleaftype(U) ? Nullable{U}() : Nullable()
+          end
+      end
+    else # Inference fails with the previous branch on Julia 0.5
+      if isdefined(f, :instance)
+          U = Core.Inference.return_type(f.instance, map(eltype_nullable, xs.parameters))
+          isleaftype(U) || (U = Union{})
+      elseif F === DataType # Function is a constructor
+          U = f.parameters[1]
+      else
+          U = Union{}
+      end
+      return quote
+          if (&)($(checknull...))
+              return Nullable(f($(args...)))
+          else
+              return Nullable{$U}()
           end
       end
     end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -36,6 +36,10 @@ module TestBroadcast
     f(x::Real, y::Real) = x * y
     f(x::Real, y::Real, z::Real) = x * y * z
 
+    @inferred NullableArrays.lift(f, (1,))
+    @inferred NullableArrays.lift(f, (1, 2.0))
+    @inferred NullableArrays.lift(f, (1, 2.0, 3.0))
+
     for (dests, arrays, nullablearrays, mask) in
         ( ((C2, Z2), (A1, A2), (U1, U2), ()),
           ((C3, Z3), (A2, A3), (U2, U3), ()),
@@ -105,5 +109,16 @@ module TestBroadcast
     Y = NullableArray(B, M2)
     @test isequal(broadcast(&, X, Y), NullableArray(A .& B, M1 .| M2))
     @test isequal(broadcast(|, X, Y), NullableArray(A .| B, M1 .| M2))
+
+    # Test broadcasting with constructor
+    immutable SurvEvent
+        time::Float64
+        censored::Bool
+    end
+    t = NullableArray(rand(3))
+    c = NullableArray(rand(Bool, 3))
+    @test isequal(SurvEvent.(t, c), NullableArray([SurvEvent(get(t[i]), get(c[i])) for i in 1:3]))
+    @test isa(SurvEvent.(t, c), NullableVector{SurvEvent})
+    @inferred NullableArrays.lift(SurvEvent, (1, true))
 
 end # module


### PR DESCRIPTION
Non-singleton types do not have an 'instance' field, so we cannot call
null_safe_op() from a generated function for them. This means they will
always be considered as unsafe.

Unfortunately, this means that the return type cannot be computed from
the generated function either, and type inference only works on Julia 0.6.

Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/176.