### PR TITLE
Add dropnull!

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -15,6 +15,7 @@ export NullableArray,
 
        # Methods
        dropnull,
+       dropnull!,
        anynull,
        allnull,
        nullify!,

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -169,7 +169,7 @@ function dropnull{T}(X::AbstractVector{T})                  # -> AbstractVector
         for i in eachindex(Y, res)
             @inbounds res[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
         end
-        res
+        return res
     end
 end
 dropnull(X::NullableVector) = X.values[!X.isnull]                   # -> Vector
@@ -190,7 +190,7 @@ function dropnull!{T}(X::AbstractVector{T})                 # -> AbstractVector
         for i in eachindex(X, res)
             @inbounds res[i] = isa(X[i], Nullable) ? X[i].value : X[i]
         end
-        res
+        return res
     end
 end
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -162,11 +162,10 @@ unwrapping `Nullable` entries. A copy is always returned, even when
 """
 function dropnull(X::AbstractVector)                 # -> AbstractVector
     Y = filter(x->!_isnull(x), X)
-    res = similar(Y)
-    for i in eachindex(Y, res)
-        res[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
+    for i in eachindex(Y)
+        Y[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
     end
-    res
+    Y
 end
 function dropnull{T<:Nullable}(X::AbstractVector{T}) # -> AbstractVector
     Y = filter(x->!_isnull(x), X)
@@ -181,9 +180,11 @@ dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 """
     dropnull!(X::AbstractVector)
 
-Remove the null entries of `X` inplace.
+Remove null entries of `X` inplace. No-op if no nulls are present. Does not
+unwrap `Nullable` entries. Use `dropnull` to remove nulls AND unwrap nullables.
 """
-dropnull!(X::AbstractVector) = convert(Vector, deleteat!(X, find(isnull, X)))
+dropnull!(X::AbstractVector) = deleteat!(X, find(isnull, X))
+dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull))
 
 """
     anynull(X)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -185,10 +185,6 @@ dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 
 Remove null entries of `X` in-place and return the updated vector. This is a
 no-op if no nulls are present.
-
-    dropnull!(X::NullableVector)
-
-Remove null entries of `X` in-place and return a `Vector` view of `X.values`
 """
 function dropnull!(X::AbstractVector)
     if !(Nullable <: eltype(X))
@@ -199,6 +195,12 @@ end
 function dropnull!{T<:Nullable}(X::AbstractVector{T})
     deleteat!(X, find(isnull, X))
 end
+
+"""
+    dropnull!(X::NullableVector)
+
+Remove null entries of `X` in-place and return a `Vector` view of `X.values`
+"""
 # TODO: replace `find(X.isnull)` with `X.isnull` when
 # https://github.com/JuliaLang/julia/pull/20465 is merged and part of
 # current release (either v0.6 or v1.0)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -199,6 +199,9 @@ end
 function dropnull!{T<:Nullable}(X::AbstractVector{T})
     deleteat!(X, find(isnull, X))
 end
+# TODO: replace `find(X.isnull)` with `X.isnull` when
+# https://github.com/JuliaLang/julia/pull/20465 is merged and part of
+# current release (either v0.6 or v1.0)
 dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values
 
 """

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -180,11 +180,13 @@ dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 """
     dropnull!(X::AbstractVector)
 
-Remove null entries of `X` inplace. No-op if no nulls are present. Does not
-unwrap `Nullable` entries. Use `dropnull` to remove nulls AND unwrap nullables.
+Remove null entries of `X` inplace, and return the updated `Vector` of the same
+type as the input vector. No-op if no nulls are present. If `X` is
+a `NullableVector` then a view of the unwrapped values is returned for
+convenience, although `X` itself will still be a `NullableVector`
 """
 dropnull!(X::AbstractVector) = deleteat!(X, find(isnull, X))
-dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull))
+dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values
 
 """
     anynull(X)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -183,17 +183,28 @@ dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 """
     dropnull!(X::AbstractVector)
 
-Remove null entries of `X` in-place and return the updated vector. This is a
-no-op if no nulls are present.
+Remove null entries of `X` in-place and return a `Vector` view of the
+unwrapped `Nullable` entries. If no nulls are present, this is a no-op
+and `X` is returned.
 """
 function dropnull!(X::AbstractVector)
     if !(Nullable <: eltype(X))
         return X
     end
     deleteat!(X, find(isnull, X))
+    res = similar(X)
+    for i in eachindex(X, res)
+        res[i] = isa(X[i], Nullable) ? X[i].value : X[i]
+    end
+    res
 end
 function dropnull!{T<:Nullable}(X::AbstractVector{T})
     deleteat!(X, find(isnull, X))
+    res = similar(X, eltype(T))
+    for i in eachindex(X, res)
+        res[i] = X[i].value
+    end
+    res
 end
 
 """

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -183,19 +183,21 @@ dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 """
     dropnull!(X::AbstractVector)
 
-Remove null entries of `X` in-place and return the updated vector. No-op
-if no nulls are present. If `X` is a `NullableVector`, a view of the
-unwrapped values is returned for convenience, although `X` itself will still
-be a `NullableVector`.
+Remove null entries of `X` in-place and return the updated vector. This is a
+no-op if no nulls are present.
+
+    dropnull!(X::NullableVector)
+
+Remove null entries of `X` in-place and return a `Vector` view of `X.values`
 """
 function dropnull!(X::AbstractVector)
-	if !(Nullable <: eltype(X))
-		return X
-	end
-	deleteat!(X, find(isnull, X))
+    if !(Nullable <: eltype(X))
+        return X
+    end
+    deleteat!(X, find(isnull, X))
 end
 function dropnull!{T<:Nullable}(X::AbstractVector{T})
-	deleteat!(X, find(isnull, X))
+    deleteat!(X, find(isnull, X))
 end
 dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -161,6 +161,9 @@ unwrapping `Nullable` entries. A copy is always returned, even when
 `X` does not contain any null values.
 """
 function dropnull(X::AbstractVector)                 # -> AbstractVector
+    if !(Nullable <: eltype(X))
+        return X
+    end
     Y = filter(x->!_isnull(x), X)
     for i in eachindex(Y)
         Y[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
@@ -180,12 +183,20 @@ dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 """
     dropnull!(X::AbstractVector)
 
-Remove null entries of `X` inplace, and return the updated `Vector` of the same
-type as the input vector. No-op if no nulls are present. If `X` is
-a `NullableVector` then a view of the unwrapped values is returned for
-convenience, although `X` itself will still be a `NullableVector`
+Remove null entries of `X` in-place and return the updated vector. No-op
+if no nulls are present. If `X` is a `NullableVector`, a view of the
+unwrapped values is returned for convenience, although `X` itself will still
+be a `NullableVector`.
 """
-dropnull!(X::AbstractVector) = deleteat!(X, find(isnull, X))
+function dropnull!(X::AbstractVector)
+	if !(Nullable <: eltype(X))
+		return X
+	end
+	deleteat!(X, find(isnull, X))
+end
+function dropnull!{T<:Nullable}(X::AbstractVector{T})
+	deleteat!(X, find(isnull, X))
+end
 dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values
 
 """

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -160,7 +160,7 @@ Return a vector containing only the non-null entries of `X`,
 unwrapping `Nullable` entries. A copy is always returned, even when
 `X` does not contain any null values.
 """
-function dropnull{T}(X::AbstractVector{T})
+function dropnull{T}(X::AbstractVector{T})                  # -> AbstractVector
     if !(Nullable <: T) && !(T <: Nullable)
         return copy(X)
     else
@@ -172,7 +172,7 @@ function dropnull{T}(X::AbstractVector{T})
         res
     end
 end
-dropnull(X::NullableVector) = X.values[!X.isnull]
+dropnull(X::NullableVector) = X.values[!X.isnull]                   # -> Vector
 
 """
     dropnull!(X::AbstractVector)
@@ -181,7 +181,7 @@ Remove null entries of `X` in-place and return a `Vector` view of the
 unwrapped `Nullable` entries. If no nulls are present, this is a no-op
 and `X` is returned.
 """
-function dropnull!{T}(X::AbstractVector{T})
+function dropnull!{T}(X::AbstractVector{T})                 # -> AbstractVector
     if !(Nullable <: T) && !(T <: Nullable)
         return X
     else
@@ -203,7 +203,7 @@ unwrapped `Nullable` entries.
 # TODO: replace `find(X.isnull)` with `X.isnull` when
 # https://github.com/JuliaLang/julia/pull/20465 is merged and part of
 # current release (either v0.6 or v1.0)
-dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values
+dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values # -> Vector
 
 """
     anynull(X)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -179,6 +179,13 @@ end
 dropnull(X::NullableVector) = X.values[!X.isnull]    # -> Vector
 
 """
+    dropnull!(X::AbstractVector)
+
+Remove the null entries of `X` inplace.
+"""
+dropnull!(X::AbstractVector) = convert(Vector, deleteat!(X, find(isnull, X)))
+
+"""
     anynull(X)
 
 Returns whether or not any entries of `X` are null.

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -257,7 +257,7 @@ null entries will result in an error.
 Currently supported return type arguments include: `Array`, `Array{T}`,
 `Vector`, `Matrix`.
 
-`convert(T, X::NullableArray, replacement)`
+    convert(T, X::NullableArray, replacement)
 
 Convert `X` to an `AbstractArray` of type `T` and replace all null entries of
 `X` with `replacement` in the result.

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -166,7 +166,7 @@ function dropnull(X::AbstractVector)                 # -> AbstractVector
     end
     Y = filter(x->!_isnull(x), X)
     for i in eachindex(Y)
-        Y[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
+        @inbounds Y[i] = isa(Y[i], Nullable) ? Y[i].value : Y[i]
     end
     Y
 end
@@ -174,7 +174,7 @@ function dropnull{T<:Nullable}(X::AbstractVector{T}) # -> AbstractVector
     Y = filter(x->!_isnull(x), X)
     res = similar(Y, eltype(T))
     for i in eachindex(Y, res)
-        res[i] = Y[i].value
+        @inbounds res[i] = Y[i].value
     end
     res
 end
@@ -194,7 +194,7 @@ function dropnull!(X::AbstractVector)
     deleteat!(X, find(isnull, X))
     res = similar(X)
     for i in eachindex(X, res)
-        res[i] = isa(X[i], Nullable) ? X[i].value : X[i]
+        @inbounds res[i] = isa(X[i], Nullable) ? X[i].value : X[i]
     end
     res
 end
@@ -202,7 +202,7 @@ function dropnull!{T<:Nullable}(X::AbstractVector{T})
     deleteat!(X, find(isnull, X))
     res = similar(X, eltype(T))
     for i in eachindex(X, res)
-        res[i] = X[i].value
+        @inbounds res[i] = X[i].value
     end
     res
 end

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -199,7 +199,8 @@ end
 """
     dropnull!(X::NullableVector)
 
-Remove null entries of `X` in-place and return a `Vector` view of `X.values`
+Remove null entries of `X` in-place and return a `Vector` view of the
+unwrapped `Nullable` entries.
 """
 # TODO: replace `find(X.isnull)` with `X.isnull` when
 # https://github.com/JuliaLang/julia/pull/20465 is merged and part of

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -162,7 +162,7 @@ unwrapping `Nullable` entries. A copy is always returned, even when
 """
 function dropnull(X::AbstractVector)                 # -> AbstractVector
     if !(Nullable <: eltype(X))
-        return X
+        return copy(X)
     end
     Y = filter(x->!_isnull(x), X)
     for i in eachindex(Y)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -180,14 +180,20 @@ module TestPrimitives
     A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
             Nullable(), Nullable(7), Nullable()]
     # dropnull(X::AbstractVector{<:Nullable})
-    B = convert(Vector{Nullable}, A)
-    @test dropnull(z) == dropnull!(z) == [1, 2, 3, 5, 7]
-    @test dropnull(A) == dropnull!(A) == [1, 2, 3, 5, 7]
-    @test dropnull(B) == dropnull!(B) == [1, 2, 3, 5, 7]
+    B = [Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
+            Nullable(), Nullable(7), Nullable()]
+    @test dropnull(z) == [1, 2, 3, 5, 7]
+    @test dropnull(A) == [1, 2, 3, 5, 7]
+    @test dropnull(B) == [1, 2, 3, 5, 7]
+    @test isequal(dropnull!(z), Nullable[1, 2, 3, 5, 7])
+    @test isequal(dropnull!(A), Any[Nullable(1), Nullable(2), Nullable(3),
+                                        Nullable(5), Nullable(7)])
+    @test isequal(dropnull!(B),  Nullable[1, 2, 3, 5, 7])
 
 # ----- test anynull ---------------------------------------------------------#
 
     # anynull(X::NullableArray)
+    z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
     @test anynull(z) == true
     @test anynull(dropnull(z)) == false
     z = NullableArray(Int, 10)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -174,16 +174,16 @@ module TestPrimitives
 
 # ----- test dropnull --------------------------------------------------------#
 
-    # dropnull(X::NullableArray)
+    # dropnull(X::NullableVector)
     z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
     @test dropnull(z) == [1, 2, 3, 5, 7]
 
-    # dropnull(X::AbstractArray)
+    # dropnull(X::AbstractVector)
     A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
             Nullable(), Nullable(7), Nullable()]
     @test dropnull(A) == [1, 2, 3, 5, 7]
 
-    # dropnull(X::AbstractArray{<:Nullable})
+    # dropnull(X::AbstractVector{<:Nullable})
     B = convert(Vector{Nullable}, A)
     @test dropnull(B) == [1, 2, 3, 5, 7]
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -194,6 +194,12 @@ module TestPrimitives
                                     Nullable(5), Nullable(7)])
     @test isequal(dropnull!(B),  Nullable[1, 2, 3, 5, 7])
     @test isequal(B,  Nullable[1, 2, 3, 5, 7])
+    # when no nulls present, dropnull returns copy and dropnull! returns X
+    nullfree = [1,2,3,4]
+    out_copy = dropnull(nullfree)
+    out_inplace = dropnull!(nullfree)
+    @test nullfree == out_copy && !(nullfree === out_copy)
+    @test nullfree == out_inplace && nullfree === out_inplace
 
 # ----- test anynull ---------------------------------------------------------#
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -182,7 +182,7 @@ module TestPrimitives
     # dropnull(X::AbstractVector{<:Nullable})
     B = convert(Vector{Nullable}, A)
     @test dropnull(z) == dropnull!(z) == [1, 2, 3, 5, 7]
-    @test dropnull(A) == dropnull!(A) == Any[1, 2, 3, 5, 7]
+    @test dropnull(A) == dropnull!(A) == [1, 2, 3, 5, 7]
     @test dropnull(B) == dropnull!(B) == [1, 2, 3, 5, 7]
 
 # ----- test anynull ---------------------------------------------------------#

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -196,17 +196,18 @@ module TestPrimitives
 
     # for each, assert returned values are unwrapped and inplace change
     # dropnull!(X::NullableVector)
-    @test isequal(dropnull!(z), [1, 2, 3, 5, 7])
-    @test isequal(z, Nullable[1, 2, 3, 5, 7])
+    @test dropnull!(z) == [1, 2, 3, 5, 7]
+    @test isequal(z, NullableArray([1, 2, 3, 5, 7]))
 
     # dropnull!(X::AbstractVector)
-    @test isequal(dropnull!(A), [1, 2, 3, 5, 7])
+    @test dropnull!(A) == [1, 2, 3, 5, 7]
     @test isequal(A, Any[Nullable(1), Nullable(2), Nullable(3), Nullable(5),
                          Nullable(7)])
 
     # dropnull!(X::AbstractVector{<:Nullable})
-    @test isequal(dropnull!(B), [1, 2, 3, 5, 7])
-    @test isequal(B, Nullable[1, 2, 3, 5, 7])
+    @test dropnull!(B) == [1, 2, 3, 5, 7]
+    @test isequal(B, [Nullable(1), Nullable(2), Nullable(3), Nullable(5),
+                      Nullable(7)])
 
     # when no nulls present, dropnull! returns input vector
     returned_view = dropnull!(nullfree)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -172,20 +172,18 @@ module TestPrimitives
     z = NullableArray([false, true, false, true, false, true])
     @test isequal(find(z), [2, 4, 6])
 
-# ----- test dropnull --------------------------------------------------------#
+# ----- test dropnull & dropnull! ---------------------------------------------#
 
     # dropnull(X::NullableVector)
     z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
-    @test dropnull(z) == [1, 2, 3, 5, 7]
-
     # dropnull(X::AbstractVector)
     A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
             Nullable(), Nullable(7), Nullable()]
-    @test dropnull(A) == [1, 2, 3, 5, 7]
-
     # dropnull(X::AbstractVector{<:Nullable})
     B = convert(Vector{Nullable}, A)
-    @test dropnull(B) == [1, 2, 3, 5, 7]
+    @test dropnull(z) == dropnull!(z) == [1, 2, 3, 5, 7]
+    @test dropnull(A) == dropnull!(A) == Any[1, 2, 3, 5, 7]
+    @test dropnull(B) == dropnull!(B) == [1, 2, 3, 5, 7]
 
 # ----- test anynull ---------------------------------------------------------#
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -206,8 +206,7 @@ module TestPrimitives
 
     # dropnull!(X::AbstractVector{<:Nullable})
     @test dropnull!(B) == [1, 2, 3, 5, 7]
-    @test isequal(B, [Nullable(1), Nullable(2), Nullable(3), Nullable(5),
-                      Nullable(7)])
+    @test isequal(B, Nullable[1, 2, 3, 5, 7])
 
     # when no nulls present, dropnull! returns input vector
     returned_view = dropnull!(nullfree)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -180,12 +180,12 @@ module TestPrimitives
 
     # dropnull(X::AbstractVector)
     A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
-           Nullable(), Nullable(7), Nullable()]
+            Nullable(), Nullable(7), Nullable()]
     @test dropnull(A) == [1, 2, 3, 5, 7]
 
     # dropnull(X::AbstractVector{<:Nullable})
     B = [Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
-        Nullable(), Nullable(7), Nullable()]
+         Nullable(), Nullable(7), Nullable()]
     @test dropnull(B) == [1, 2, 3, 5, 7]
     # assert dropnull returns copy for !(Nullable <: eltype(X))
     nullfree = [1, 2, 3, 4]
@@ -202,7 +202,7 @@ module TestPrimitives
     # dropnull!(X::AbstractVector)
     @test isequal(dropnull!(A), [1, 2, 3, 5, 7])
     @test isequal(A, Any[Nullable(1), Nullable(2), Nullable(3), Nullable(5),
-                        Nullable(7)])
+                         Nullable(7)])
 
     # dropnull!(X::AbstractVector{<:Nullable})
     @test isequal(dropnull!(B), [1, 2, 3, 5, 7])
@@ -213,12 +213,12 @@ module TestPrimitives
     @test nullfree == returned_view && nullfree === returned_view
 
     # test that dropnull! returns unwrapped values when nullables are present
-    X = [false, 1, :c, "string", Nullable("I am a null"), Nullable()]
-    @test any(map(x -> isa(x, Nullable), dropnull!(X))) == false
-    @test any(map(x -> isa(x, Nullable), X)) == true
-    Y = Any[false, 1, :c, "string", Nullable("I am a null"), Nullable()]
-    @test any(map(x -> isa(x, Nullable), dropnull!(Y))) == false
-    @test any(map(x -> isa(x, Nullable), Y)) == true
+    X = [false, 1, :c, "string", Nullable("I am not null"), Nullable()]
+    @test !any(x -> isa(x, Nullable), dropnull!(X))
+    @test any(x -> isa(x, Nullable), X)
+    Y = Any[false, 1, :c, "string", Nullable("I am not null"), Nullable()]
+    @test !any(x -> isa(x, Nullable), dropnull!(Y))
+    @test any(x -> isa(x, Nullable), Y)
 
 # ----- test anynull ---------------------------------------------------------#
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -185,10 +185,15 @@ module TestPrimitives
     @test dropnull(z) == [1, 2, 3, 5, 7]
     @test dropnull(A) == [1, 2, 3, 5, 7]
     @test dropnull(B) == [1, 2, 3, 5, 7]
-    @test isequal(dropnull!(z), Nullable[1, 2, 3, 5, 7])
+    # for each inplace, assert both proper return value and inplace change
+    @test isequal(dropnull!(z), [1, 2, 3, 5, 7])
+    @test isequal(z, Nullable[1, 2, 3, 5, 7])
     @test isequal(dropnull!(A), Any[Nullable(1), Nullable(2), Nullable(3),
                                         Nullable(5), Nullable(7)])
+    @test isequal(A, Any[Nullable(1), Nullable(2), Nullable(3),
+                                    Nullable(5), Nullable(7)])
     @test isequal(dropnull!(B),  Nullable[1, 2, 3, 5, 7])
+    @test isequal(B,  Nullable[1, 2, 3, 5, 7])
 
 # ----- test anynull ---------------------------------------------------------#
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -179,13 +179,11 @@ module TestPrimitives
     @test dropnull(z) == [1, 2, 3, 5, 7]
 
     # dropnull(X::AbstractVector)
-    A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
-            Nullable(), Nullable(7), Nullable()]
+    A = Any[1, 2, 3, Nullable(), 5, Nullable(), 7, Nullable()]
     @test dropnull(A) == [1, 2, 3, 5, 7]
 
     # dropnull(X::AbstractVector{<:Nullable})
-    B = [Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
-         Nullable(), Nullable(7), Nullable()]
+    B = Nullable[1, 2, 3, Nullable(), 5, Nullable(), 7, Nullable()]
     @test dropnull(B) == [1, 2, 3, 5, 7]
     # assert dropnull returns copy for !(Nullable <: eltype(X))
     nullfree = [1, 2, 3, 4]
@@ -201,8 +199,7 @@ module TestPrimitives
 
     # dropnull!(X::AbstractVector)
     @test dropnull!(A) == [1, 2, 3, 5, 7]
-    @test isequal(A, Any[Nullable(1), Nullable(2), Nullable(3), Nullable(5),
-                         Nullable(7)])
+    @test isequal(A, Any[1, 2, 3, 5, 7])
 
     # dropnull!(X::AbstractVector{<:Nullable})
     @test dropnull!(B) == [1, 2, 3, 5, 7]

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -195,7 +195,7 @@ module TestPrimitives
     @test isequal(dropnull!(B),  Nullable[1, 2, 3, 5, 7])
     @test isequal(B,  Nullable[1, 2, 3, 5, 7])
     # when no nulls present, dropnull returns copy and dropnull! returns X
-    nullfree = [1,2,3,4]
+    nullfree = [1, 2, 3, 4]
     out_copy = dropnull(nullfree)
     out_inplace = dropnull!(nullfree)
     @test nullfree == out_copy && !(nullfree === out_copy)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -177,10 +177,12 @@ module TestPrimitives
     # dropnull(X::NullableVector)
     z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
     @test dropnull(z) == [1, 2, 3, 5, 7]
+
     # dropnull(X::AbstractVector)
     A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
            Nullable(), Nullable(7), Nullable()]
     @test dropnull(A) == [1, 2, 3, 5, 7]
+
     # dropnull(X::AbstractVector{<:Nullable})
     B = [Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
         Nullable(), Nullable(7), Nullable()]
@@ -196,16 +198,20 @@ module TestPrimitives
     # dropnull!(X::NullableVector)
     @test isequal(dropnull!(z), [1, 2, 3, 5, 7])
     @test isequal(z, Nullable[1, 2, 3, 5, 7])
+
     # dropnull!(X::AbstractVector)
     @test isequal(dropnull!(A), [1, 2, 3, 5, 7])
     @test isequal(A, Any[Nullable(1), Nullable(2), Nullable(3), Nullable(5),
                         Nullable(7)])
+
     # dropnull!(X::AbstractVector{<:Nullable})
     @test isequal(dropnull!(B), [1, 2, 3, 5, 7])
     @test isequal(B, Nullable[1, 2, 3, 5, 7])
+
     # when no nulls present, dropnull! returns input vector
     out_inplace = dropnull!(nullfree)
     @test nullfree == out_inplace && nullfree === out_inplace
+
     # test that dropnull! returns unwrapped values when nullables are present
     X = [false, 1, :c, "string", Nullable("I am a null"), Nullable()]
     @test any(map(x -> isa(x, Nullable), dropnull!(X))) == false

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -209,8 +209,8 @@ module TestPrimitives
     @test isequal(B, Nullable[1, 2, 3, 5, 7])
 
     # when no nulls present, dropnull! returns input vector
-    out_inplace = dropnull!(nullfree)
-    @test nullfree == out_inplace && nullfree === out_inplace
+    returned_view = dropnull!(nullfree)
+    @test nullfree == returned_view && nullfree === returned_view
 
     # test that dropnull! returns unwrapped values when nullables are present
     X = [false, 1, :c, "string", Nullable("I am a null"), Nullable()]

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -183,7 +183,7 @@ module TestPrimitives
     @test dropnull(A) == [1, 2, 3, 5, 7]
 
     # dropnull(X::AbstractVector{<:Nullable})
-    B = Nullable[1, 2, 3, Nullable(), 5, Nullable(), 7, Nullable()]
+    B = [1, 2, 3, Nullable(), 5, Nullable(), 7, Nullable()]
     @test dropnull(B) == [1, 2, 3, 5, 7]
     # assert dropnull returns copy for !(Nullable <: eltype(X))
     nullfree = [1, 2, 3, 4]


### PR DESCRIPTION
I wanted to add a `dropnull!` function here before extending both `dropnull` and `dropnull!` in DataFrames (see https://github.com/JuliaStats/DataFrames.jl/issues/602 https://github.com/JuliaStats/DataFrames.jl/issues/1156)

This pull request currently does not pass the test cases that have been established for the current `dropnull` function, which I have used for testing `dropnull!`
```julia
using NullableArrays
using BenchmarkTools
using Base.Test

# dropnull(X::NullableVector)
z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
# dropnull(X::AbstractVector)
A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
		Nullable(), Nullable(7), Nullable()]
# dropnull(X::AbstractVector{<:Nullable})
B = convert(Vector{Nullable}, A)
@test dropnull(z) == dropnull!(z) == [1, 2, 3, 5, 7]
@test dropnull(A) == dropnull!(A) == [1, 2, 3, 5, 7]
@test dropnull(B) == dropnull!(B) == [1, 2, 3, 5, 7]
```

output
```julia
julia> @test dropnull(z) == dropnull!(z) == [1, 2, 3, 5, 7]
Test Passed
  Expression: $(Expr(:escape, :(dropnull(z)))) $(Expr(:escape, :(==))) $(Expr(:escape, :(dropnull!(z)))) $(Expr(:escape, :(==))) $(Expr(:escape, :([1,2,3,5,7])))
   Evaluated: [1,2,3,5,7] == [1,2,3,5,7] == [1,2,3,5,7]

julia> @test dropnull(A) == dropnull!(A) == [1, 2, 3, 5, 7]
Test Failed
  Expression: $(Expr(:escape, :(dropnull(A)))) $(Expr(:escape, :(==))) $(Expr(:escape, :(dropnull!(A)))) $(Expr(:escape, :(==))) $(Expr(:escape, :([1,2,3,5,7])))
   Evaluated: Any[1,2,3,5,7] == Any[1,2,3,5,7] == [1,2,3,5,7]
ERROR: There was an error during testing
 in record(::Base.Test.FallbackTestSet, ::Base.Test.Fail) at ./test.jl:397
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281

julia> @test dropnull(B) == dropnull!(B) == [1, 2, 3, 5, 7]
Test Failed
  Expression: $(Expr(:escape, :(dropnull(B)))) $(Expr(:escape, :(==))) $(Expr(:escape, :(dropnull!(B)))) $(Expr(:escape, :(==))) $(Expr(:escape, :([1,2,3,5,7])))
   Evaluated: Any[1,2,3,5,7] == Nullable[1,2,3,5,7] == [1,2,3,5,7]
ERROR: There was an error during testing
 in record(::Base.Test.FallbackTestSet, ::Base.Test.Fail) at ./test.jl:397
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281
```

It's unclear to me why in the second test case `dropnull` passes while `dropnull!` doesn't even though the outputs are both `Array{Any,1}`. Using `isequal()` does not change the test outcome.
```julia
julia> @test dropnull(A) == [1, 2, 3, 5, 7]
Test Passed
  Expression: dropnull(A) == [1,2,3,5,7]
   Evaluated: Any[1,2,3,5,7] == [1,2,3,5,7]

julia> @test dropnull!(A) == [1, 2, 3, 5, 7]
Test Failed
  Expression: dropnull!(A) == [1,2,3,5,7]
   Evaluated: Any[1,2,3,5,7] == [1,2,3,5,7]
ERROR: There was an error during testing
 in record(::Base.Test.FallbackTestSet, ::Base.Test.Fail) at ./test.jl:397
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281

 julia> A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
                               Nullable(), Nullable(7), Nullable()];

 julia> typeof(dropnull(A))
 Array{Any,1}

 julia> typeof(dropnull!(A))
 Array{Any,1}

 julia> A = Any[Nullable(1), Nullable(2), Nullable(3), Nullable(), Nullable(5),
                               Nullable(), Nullable(7), Nullable()];

 julia> eltype(dropnull(A))
 Any

 julia> eltype(dropnull!(A))
 Any
```

I'm also interested in feedback on the third test case, where `dropnull` produces `Array{Any,1}` and `dropnull!` produces `Array{Nullable,1}`. Is there a reason to prefer one over the other?
```julia
julia> @test dropnull(B) == dropnull!(B) == [1, 2, 3, 5, 7]
Test Failed
  Expression: $(Expr(:escape, :(dropnull(B)))) $(Expr(:escape, :(==))) $(Expr(:escape, :(dropnull!(B)))) $(Expr(:escape, :(==))) $(Expr(:escape, :([1,2,3,5,7])))
   Evaluated: Any[1,2,3,5,7] == Nullable[1,2,3,5,7] == [1,2,3,5,7]
ERROR: There was an error during testing
 in record(::Base.Test.FallbackTestSet, ::Base.Test.Fail) at ./test.jl:397
 in do_test(::Base.Test.Returned, ::Expr) at ./test.jl:281
```

The benchmarks look ok except for `dropnull!(C)`, where the inplace version is slower than `dropnull(C)` for reasons I don't understand. `dropnull!(D)` makes more allocations than `dropnull(D)` but is still faster

benchmark
```julia
srand(1)
A = NullableArray(rand([0, 1, Nullable()], Int(1e6)));
B = rand([0, 1, Nullable()], Int(1e6));
C = NullableArray(rand([:Q, 1, Nullable()], Int(1e6)));
D = rand([:Q, 1, Nullable()], Int(1e6));
@benchmark dropnull(A)
@benchmark dropnull!(A)
@benchmark dropnull(B)
@benchmark dropnull!(B)
@benchmark dropnull(C)
@benchmark dropnull!(C)
@benchmark dropnull(D)
@benchmark dropnull!(D)
```

results
```julia
julia> @benchmark dropnull(A)
BenchmarkTools.Trial:
  memory estimate:  6.03 mb
  allocs estimate:  6
  --------------
  minimum time:     5.301 ms (0.00% GC)
  median time:      6.044 ms (0.00% GC)
  mean time:        6.306 ms (4.95% GC)
  maximum time:     10.372 ms (13.32% GC)
  --------------
  samples:          793
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull!(A)
BenchmarkTools.Trial:
  memory estimate:  288.00 bytes
  allocs estimate:  4
  --------------
  minimum time:     998.744 μs (0.00% GC)
  median time:      1.081 ms (0.00% GC)
  mean time:        1.139 ms (0.00% GC)
  maximum time:     2.752 ms (0.00% GC)
  --------------
  samples:          4388
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull(B)
BenchmarkTools.Trial:
  memory estimate:  22.09 mb
  allocs estimate:  22
  --------------
  minimum time:     14.614 ms (9.83% GC)
  median time:      15.192 ms (10.47% GC)
  mean time:        15.631 ms (10.36% GC)
  maximum time:     19.828 ms (9.03% GC)
  --------------
  samples:          320
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull!(B)
BenchmarkTools.Trial:
  memory estimate:  160.00 bytes
  allocs estimate:  2
  --------------
  minimum time:     564.757 μs (0.00% GC)
  median time:      606.058 μs (0.00% GC)
  mean time:        634.440 μs (0.00% GC)
  maximum time:     1.357 ms (0.00% GC)
  --------------
  samples:          7862
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull(C)
BenchmarkTools.Trial:
  memory estimate:  6.05 mb
  allocs estimate:  6
  --------------
  minimum time:     6.013 ms (0.00% GC)
  median time:      6.934 ms (0.00% GC)
  mean time:        7.086 ms (4.10% GC)
  maximum time:     10.903 ms (17.99% GC)
  --------------
  samples:          706
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull!(C)
BenchmarkTools.Trial:
  memory estimate:  71.37 mb
  allocs estimate:  2004545
  --------------
  minimum time:     59.823 ms (8.33% GC)
  median time:      66.289 ms (9.09% GC)
  mean time:        66.455 ms (9.15% GC)
  maximum time:     76.234 ms (11.40% GC)
  --------------
  samples:          76
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull(D)
BenchmarkTools.Trial:
  memory estimate:  14.09 mb
  allocs estimate:  22
  --------------
  minimum time:     12.920 ms (0.00% GC)
  median time:      15.949 ms (9.93% GC)
  mean time:        15.856 ms (7.98% GC)
  maximum time:     22.595 ms (20.56% GC)
  --------------
  samples:          316
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark dropnull!(D)
BenchmarkTools.Trial:
  memory estimate:  20.37 mb
  allocs estimate:  667464
  --------------
  minimum time:     3.712 ms (0.00% GC)
  median time:      4.898 ms (18.68% GC)
  mean time:        5.015 ms (18.00% GC)
  maximum time:     8.406 ms (18.44% GC)
  --------------
  samples:          997
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```

I think that's enough questions for one post. Thanks in advance for any advice on how to proceed.