### PR TITLE
Fix Julia 0.6 deprecations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -F -e "versioninfo();
+  - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"NullableArrays\"); Pkg.build(\"NullableArrays\")"
 
 test_script:

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -2,7 +2,7 @@
 
 importall Base.Operators
 import Base: promote_op, abs, abs2, sqrt, cbrt, scalarmin, scalarmax, isless
-using Compat: @functorize
+using Compat: @compat, @functorize
 
 if isdefined(Base, :fieldname) && Base.fieldname(Nullable, 1) == :hasvalue # Julia 0.6
     _Nullable(R, x, hasvalue::Bool) = Nullable{R}(x, hasvalue)
@@ -38,16 +38,16 @@ vectorization.
 """
 null_safe_op(f::Any, ::Type...) = false
 
-typealias SafeSignedInts Union{Int128,Int16,Int32,Int64,Int8}
-typealias SafeUnsignedInts Union{Bool,UInt128,UInt16,UInt32,UInt64,UInt8}
-typealias SafeInts  Union{SafeSignedInts,SafeUnsignedInts}
-typealias SafeFloats Union{Float16,Float32,Float64}
+@compat const SafeSignedInts = Union{Int128,Int16,Int32,Int64,Int8}
+@compat const SafeUnsignedInts = Union{Bool,UInt128,UInt16,UInt32,UInt64,UInt8}
+@compat const SafeInts = Union{SafeSignedInts,SafeUnsignedInts}
+@compat const SafeFloats = Union{Float16,Float32,Float64}
 
 # Float types appear in both since they promote to themselves,
 # and therefore can't fail due to conversion of negative numbers
-typealias SafeSigned Union{SafeSignedInts,SafeFloats}
-typealias SafeUnsigned Union{SafeUnsignedInts,SafeFloats}
-typealias SafeTypes Union{SafeInts,SafeFloats}
+@compat const SafeSigned = Union{SafeSignedInts,SafeFloats}
+@compat const SafeUnsigned = Union{SafeUnsignedInts,SafeFloats}
+@compat const SafeTypes = Union{SafeInts,SafeFloats}
 
 # Unary operators
 

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -172,7 +172,7 @@ function dropnull{T}(X::AbstractVector{T})                  # -> AbstractVector
         return res
     end
 end
-dropnull(X::NullableVector) = X.values[!X.isnull]                   # -> Vector
+dropnull(X::NullableVector) = X.values[(!).(X.isnull)]      # -> Vector
 
 """
     dropnull!(X::AbstractVector)

--- a/src/show.jl
+++ b/src/show.jl
@@ -9,7 +9,7 @@ if VERSION < v"0.5.0-dev+3610"
         Base.show_vector(io, X, "[", "]")
     end
 
-    abstract NULL
+    @compat abstract type NULL end
 
     Base.showcompact(io::IO, ::Type{NULL}) = show(io, NULL)
     Base.show(io::IO, ::Type{NULL}) = print(io, "#NULL")

--- a/src/subarray0_5.jl
+++ b/src/subarray0_5.jl
@@ -1,4 +1,6 @@
-typealias NullableSubArray{T,N,P<:NullableArray,IV,LD} SubArray{T,N,P,IV,LD}
+using Compat
+
+@compat NullableSubArray{T,N,P<:NullableArray,IV,LD} = SubArray{T,N,P,IV,LD}
 
 @inline function Base.isnull(V::NullableSubArray, I::Int...)
     @boundscheck checkbounds(V, I...)
@@ -10,7 +12,7 @@ end
     @inbounds return V.parent.values[Base.reindex(V, V.indexes, I)...]
 end
 
-typealias FastNullableSubArray{T,N,P<:NullableArray,IV} SubArray{T,N,P,IV,true}
+@compat FastNullableSubArray{T,N,P<:NullableArray,IV} = SubArray{T,N,P,IV,true}
 
 @inline function Base.isnull(V::FastNullableSubArray, i::Int)
     @boundscheck checkbounds(V, i)
@@ -23,7 +25,7 @@ end
 end
 
 # We can avoid a multiplication if the first parent index is a Colon or UnitRange
-typealias FastNullableContiguousSubArray{T,N,P<:NullableArray,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}}} SubArray{T,N,P,I,true}
+@compat FastNullableContiguousSubArray{T,N,P<:NullableArray,I<:Tuple{Union{Colon, UnitRange}, Vararg{Any}}} = SubArray{T,N,P,I,true}
 
 @inline function Base.isnull(V::FastNullableContiguousSubArray, i::Int)
     @boundscheck checkbounds(V, i)


### PR DESCRIPTION
The new inner constructor syntax cannot be parsed on Julia 0.5.