### PR TITLE
Fix warning about deprecated constructor syntax on Julia 0.6

### DIFF
--- a/src/typedefs.jl
+++ b/src/typedefs.jl
@@ -35,19 +35,21 @@ if VERSION >= v"0.6.0-dev.2643"
         end
     """)
 else
-    immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
-        values::Array{T, N}
-        isnull::Array{Bool, N}
-        # extra field for potentially holding a reference to a parent memory block
-        # (think mmapped file, for example) that `values` is actually derived from
-        parent::Vector{UInt8}
+    @eval begin
+        immutable NullableArray{T, N} <: AbstractArray{Nullable{T}, N}
+            values::Array{T, N}
+            isnull::Array{Bool, N}
+            # extra field for potentially holding a reference to a parent memory block
+            # (think mmapped file, for example) that `values` is actually derived from
+            parent::Vector{UInt8}
 
-        function NullableArray(d::AbstractArray{T, N}, m::AbstractArray{Bool, N}, parent::Vector{UInt8}=Vector{UInt8}())
-            if size(d) != size(m)
-                msg = "values and missingness arrays must be the same size"
-                throw(ArgumentError(msg))
+            function NullableArray(d::AbstractArray{T, N}, m::AbstractArray{Bool, N}, parent::Vector{UInt8}=Vector{UInt8}())
+                if size(d) != size(m)
+                    msg = "values and missingness arrays must be the same size"
+                    throw(ArgumentError(msg))
+                end
+                new(d, m, parent)
             end
-            new(d, m, parent)
         end
     end
 end


### PR DESCRIPTION
Turns out even parsing the code triggers the warning.