### PR TITLE
Add special lifting semantics for isnull() with map() and broadcast()

### DIFF
--- a/src/lift.jl
+++ b/src/lift.jl
@@ -23,7 +23,7 @@ return `f` applied to values of `xs`.
             nonull = (&)($(checknull...))
             @compat Nullable(val, nonull)
         end
-    elseif VERSION >= v"0.6.0-dev"
+    elseif VERSION >= v"0.6.0-dev.2544" # Commit known to work
       return quote
           U = Core.Inference.return_type(f, eltypes(xs...))
           if (&)($(checknull...))
@@ -52,3 +52,6 @@ return `f` applied to values of `xs`.
 end
 
 lift(f) = Nullable(f())
+
+lift(::typeof(isnull), xs::Tuple) = isnull(xs...)
+nullable_broadcast_eltype(::typeof(isnull), ::Any) = Bool

--- a/src/map.jl
+++ b/src/map.jl
@@ -25,7 +25,11 @@ function Base.map{F}(f::F, As::NullableArray...)
     @inline f2(x...) = lift(f, x)
 
     T = nullable_broadcast_eltype(f, As...)
-    dest = similar(NullableArray{T}, size(As[1]))
+    if T <: Nullable
+       dest = similar(NullableArray{eltype(T)}, size(As[1]))
+    else
+       dest = similar(Array{T}, size(As[1]))
+    end
     invoke_map!(f2, dest, As...)
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -121,4 +121,11 @@ module TestBroadcast
     @test isa(SurvEvent.(t, c), NullableVector{SurvEvent})
     @inferred NullableArrays.lift(SurvEvent, (1, true))
 
+    # test broadcasting with isnull()
+    A = NullableArray(1:3, [true, false, true])
+    M = @inferred broadcast(isnull, A)
+    @test M == [true, false, true]
+    broadcast!(isnull, M, A)
+    @test M == [true, false, true]
+
 end # module

--- a/test/map.jl
+++ b/test/map.jl
@@ -113,4 +113,13 @@ module TestMap
     if VERSION >= v"0.6.0-dev.2544" # Commit known to work
         @test isa(Z2, NullableArray{Int})
     end
+
+    # test map with isnull()
+    A = NullableArray(1:3, [true, false, true])
+    M = @inferred map(isnull, A)
+    @test M == [true, false, true]
+    fill!(M, false)
+    map!(isnull, M, A)
+    @test M == [true, false, true]
+
 end # module TestMap


### PR DESCRIPTION
This is needed to allow isnull.(x) to return something useful.
Currently, the nullable_broadcast_eltype() method is needed since inference
does not work on lifted functions (we need to call it on the original function).

Fixes https://github.com/JuliaStats/NullableArrays.jl/issues/180.

@davidagold @johnmyleswhite Cf. our previous discussion at https://github.com/JuliaStats/NullableArrays.jl/pull/166#issuecomment-260282404. I think https://github.com/JuliaStats/NullableArrays.jl/issues/180 makes it clear we need something like this soon.