### PR TITLE
Deprecate anynull and allnull

### DIFF
--- a/src/NullableArrays.jl
+++ b/src/NullableArrays.jl
@@ -16,8 +16,6 @@ export NullableArray,
        # Methods
        dropnull,
        dropnull!,
-       anynull,
-       allnull,
        nullify!,
        padnull!,
        padnull
@@ -34,5 +32,6 @@ include("broadcast.jl")
 include("reduce.jl")
 include("show.jl")
 include("subarray.jl")
+include("deprecated.jl")
 
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,4 @@
+using Base: @deprecate
+
+@deprecate anynull(x) any(isnull, x)
+@deprecate allnull(x) all(isnull, x)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -37,7 +37,7 @@ any component of the index `I` is null.
 """
 @inline function Base.getindex{T, N}(X::NullableArray{T, N},
                                      I::Nullable{Int}...)
-    anynull(I) && throw(NullException())
+    any(isnull, I) && throw(NullException())
     values = [ get(i) for i in I ]
     return getindex(X, values...)
 end
@@ -90,12 +90,12 @@ if VERSION >= v"0.5.0-dev+4697"
     end
 
     function Base.checkindex{N}(::Type{Bool}, inds::AbstractUnitRange, I::NullableArray{Bool, N})
-        anynull(I) && throw(NullException())
+        any(isnull, I) && throw(NullException())
         checkindex(Bool, inds, I.values)
     end
 
     function Base.checkindex{T<:Real}(::Type{Bool}, inds::AbstractUnitRange, I::NullableArray{T})
-        anynull(I) && throw(NullException())
+        any(isnull, I) && throw(NullException())
         b = true
         for i in 1:length(I)
             @inbounds v = unsafe_getvalue_notnull(I, i)
@@ -109,13 +109,13 @@ else
      end
 
     function Base.checkbounds(::Type{Bool}, sz::Int, I::NullableVector{Bool})
-         anynull(I) && throw(NullException())
+         any(isnull, I) && throw(NullException())
         length(I) == sz
      end
 
     function Base.checkbounds{T<:Real}(::Type{Bool}, sz::Int, I::NullableArray{T})
         inbounds = true
-         anynull(I) && throw(NullException())
+         any(isnull, I) && throw(NullException())
          for i in 1:length(I)
              @inbounds v = unsafe_getvalue_notnull(I, i)
             inbounds &= checkbounds(Bool, sz, v)
@@ -125,7 +125,7 @@ else
 end
 
 function Base.to_index(X::NullableArray)
-    anynull(X) && throw(NullException())
+    any(isnull, X) && throw(NullException())
     Base.to_index(X.values)
 end
 

--- a/src/nullablevector.jl
+++ b/src/nullablevector.jl
@@ -267,7 +267,7 @@ Modify `X` by reversing the first `n` elements starting at index `s`
 respectively.
 """
 function Base.reverse!(X::NullableVector, s=1, n=length(X))
-    if isbits(eltype(X)) || !anynull(X)
+    if isbits(eltype(X)) || !any(isnull, X)
         reverse!(X.values, s, n)
         reverse!(X.isnull, s, n)
     else

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -206,22 +206,6 @@ unwrapped `Nullable` entries.
 dropnull!(X::NullableVector) = deleteat!(X, find(X.isnull)).values # -> Vector
 
 """
-    anynull(X)
-
-Returns whether or not any entries of `X` are null.
-"""
-anynull(X::Any) = any(_isnull, X)           # -> Bool
-anynull(X::NullableArray) = any(X.isnull)   # -> Bool
-
-"""
-    allnull(X)
-
-Returns whether or not all the entries in `X` are null.
-"""
-allnull(X::Any) = all(_isnull, X)           # -> Bool
-allnull(X::NullableArray) = all(X.isnull)   # -> Bool
-
-"""
     isnan(X::NullableArray)
 
 Test whether each entry of `X` is null and if not, test whether the entry is
@@ -268,7 +252,7 @@ Convert `X` to an `AbstractArray` of type `T` and replace all null entries of
 """
 function Base.convert{S, T, N}(::Type{Array{S, N}},
                                X::NullableArray{T, N}) # -> Array{S, N}
-    if anynull(X)
+    if any(isnull, X)
         throw(NullException())
     else
         return convert(Array{S, N}, X.values)
@@ -339,3 +323,6 @@ function Base.float(X::NullableArray) # -> NullableArray{T, N}
     isbits(eltype(X)) || error()
     return NullableArray(float(X.values), copy(X.isnull))
 end
+
+Base.any(::typeof(isnull), X::NullableArray) = Base.any(X.isnull)
+Base.all(::typeof(isnull), X::NullableArray) = Base.all(X.isnull)

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -38,7 +38,7 @@ function mapreduce_pairwise_impl_skipnull{T}(f, op, X::NullableArray{T},
                                             blksize::Int)
     if ifirst + blksize > ilast
         # fall back to Base implementation if no nulls in block
-        # if anynull(slice(X, ifirst:ilast))
+        # if any(isnull, slice(X, ifirst:ilast))
             return mapreduce_seq_impl_skipnull(f, op, X, ifirst, ilast)
         # else
             # Nullable(Base.mapreduce_seq_impl(f, op, X.values, ifirst, ilast))
@@ -90,7 +90,7 @@ end
 # to fix ambiguity warnings
 function Base.mapreduce(f, op::Union{typeof(@functorize(&)), typeof(@functorize(|))},
                         X::NullableArray, skipnull::Bool = false)
-    missingdata = anynull(X)
+    missingdata = any(isnull, X)
     if skipnull
         return _mapreduce_skipnull(f, op, X, missingdata)
     else
@@ -117,7 +117,7 @@ Note that, in general, mapreducing over a `NullableArray` will return a
 """
 function Base.mapreduce(f, op::Function, X::NullableArray;
                         skipnull::Bool = false)
-    missingdata = anynull(X)
+    missingdata = any(isnull, X)
     if skipnull
         return _mapreduce_skipnull(f, specialized_binary(op),
                                    X, missingdata)
@@ -127,7 +127,7 @@ function Base.mapreduce(f, op::Function, X::NullableArray;
 end
 
 function Base.mapreduce(f, op, X::NullableArray; skipnull::Bool = false)
-    missingdata = anynull(X)
+    missingdata = any(isnull, X)
     if skipnull
         return _mapreduce_skipnull(f, op, X, missingdata)
     else

--- a/test/nullablevector.jl
+++ b/test/nullablevector.jl
@@ -206,7 +206,7 @@ module TestNullableVector
                   NullableArray(Array{Int, 1}[[5, 6], [3, 4], [1, 2]]))
 
     # Base.reverse!(X::NullableVector, s=1, n=length(X))
-    # check for case where isbits(eltype(X)) = false & anynull(X) = true
+    # check for case where isbits(eltype(X)) = false & any(isnull, X) = true
     A = fill([1,2], 20)
     Z = NullableArray(Array{Int, 1}, 20)
     i = rand(2:7)

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -217,53 +217,54 @@ module TestPrimitives
     @test !any(x -> isa(x, Nullable), dropnull!(Y))
     @test any(x -> isa(x, Nullable), Y)
 
-# ----- test anynull ---------------------------------------------------------#
+# ----- test any(isnull, X) --------------------------------------------------#
 
-    # anynull(X::NullableArray)
+    # any(isnull, X::NullableArray)
     z = NullableArray([1, 2, 3, 'a', 5, 'b', 7, 'c'], Int, Char)
-    @test anynull(z) == true
-    @test anynull(dropnull(z)) == false
+    @test any(isnull, z) == true
+    @test any(isnull, dropnull(z)) == false
     z = NullableArray(Int, 10)
-    @test anynull(z) == true
+    @test any(isnull, z) == true
 
-    # anynull(A::AbstractArray)
+    # any(isnull, A::AbstractArray)
     A2 = [Nullable(1), Nullable(2), Nullable(3)]
-    @test anynull(A2) == false
+    @test any(isnull, A2) == false
     push!(A2, Nullable{Int}())
-    @test anynull(A2) == true
+    @test any(isnull, A2) == true
 
-    # anynull(xs::NTuple)
-    @test anynull((Nullable(1), Nullable(2))) == false
-    @test anynull((Nullable{Int}(), Nullable(1), 3, 6)) == true
+    # any(isnull, xs::NTuple)
+    @test any(isnull, (Nullable(1), Nullable(2))) == false
+    @test any(isnull, (Nullable{Int}(), Nullable(1), 3, 6)) == true
 
-    # anynull{T, N, U<:NullableArray}(S::SubArray{T, N, U})
+    # any(isnull, S::SubArray{T, N, U<:NullableArray})
     A = rand(10, 3, 3)
     M = rand(Bool, 10, 3, 3)
     X = NullableArray(A, M)
     i, j = rand(1:3), rand(1:3)
     S = view(X, :, i, j)
 
-    @test anynull(S) == anynull(X[:, i, j])
+    @test any(isnull, S) == any(isnull, X[:, i, j])
     X = NullableArray(A)
     S = view(X, :, i, j)
-    @test anynull(S) == false
+    @test any(isnull, S) == false
 
 
-# ----- test allnull ---------------------------------------------------------#
+# ----- test all(isnull, X) --------------------------------------------------#
 
-    # allnull(X::NullableArray)
-    @test allnull(z) == true
+    # all(isnull, X::NullableArray)
+    z = NullableArray(Int, 10)
+    @test all(isnull, z) == true
     z[1] = 10
-    @test allnull(z) == false
+    @test all(isnull, z) == false
 
-    # anynull(X::AbstractArray{<:Nullable})
-    @test allnull(Nullable{Int}[Nullable(), Nullable()]) == true
-    @test allnull(Nullable{Int}[Nullable(1), Nullable()]) == false
+    # all(isnull, X::AbstractArray{<:Nullable})
+    @test all(isnull, Nullable{Int}[Nullable(), Nullable()]) == true
+    @test all(isnull, Nullable{Int}[Nullable(1), Nullable()]) == false
 
-    # anynull(X::Any)
-    @test allnull(Any[Nullable(), Nullable()]) == true
-    @test allnull([1, 2]) == false
-    @test allnull(1:3) == false
+    # all(isnull, X::Any)
+    @test all(isnull, Any[Nullable(), Nullable()]) == true
+    @test all(isnull, [1, 2]) == false
+    @test all(isnull, 1:3) == false
 
 # ----- test Base.isnan ------------------------------------------------------#
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -19,7 +19,7 @@ for i in 1:nd
 
     @test values(S, _H...) == X.values[H...]
     @test isnull(S, _H...) == X.isnull[H...]
-    @test anynull(S) == anynull(X[J...])
+    @test any(isnull, S) == any(isnull, X[J...])
 end
 
 end # module TestSubArray


### PR DESCRIPTION
Supersedes https://github.com/JuliaStats/NullableArrays.jl/pull/189. Follows the approach of DataArrays https://github.com/JuliaStats/NullableArrays.jl/pull/189#issuecomment-294309229 and removes specialization in favor of a generic optimization as proposed by https://github.com/JuliaLang/julia/issues/21256.

```julia
julia> anynull(collect(1:10))
WARNING: anynull(x) is deprecated, use any(isnull, x) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:64
 [2] anynull(::Array{Int64,1}) at ./deprecated.jl:51
 [3] eval(::Module, ::Any) at ./boot.jl:235
 [4] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [5] macro expansion at ./REPL.jl:97 [inlined]
 [6] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
false

julia> allnull(collect(1:10))
WARNING: allnull(x) is deprecated, use all(isnull, x) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:64
 [2] allnull(::Array{Int64,1}) at ./deprecated.jl:51
 [3] eval(::Module, ::Any) at ./boot.jl:235
 [4] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [5] macro expansion at ./REPL.jl:97 [inlined]
 [6] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
false

julia> allnull(NullableArray(1:10))
WARNING: allnull(x) is deprecated, use all(isnull, x) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:64
 [2] allnull(::NullableArrays.NullableArray{Int64,1}) at ./deprecated.jl:51
 [3] eval(::Module, ::Any) at ./boot.jl:235
 [4] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [5] macro expansion at ./REPL.jl:97 [inlined]
 [6] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
false

julia> anynull(NullableArray(1:10))
WARNING: anynull(x) is deprecated, use any(isnull, x) instead.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:64
 [2] anynull(::NullableArrays.NullableArray{Int64,1}) at ./deprecated.jl:51
 [3] eval(::Module, ::Any) at ./boot.jl:235
 [4] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
 [5] macro expansion at ./REPL.jl:97 [inlined]
 [6] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
while loading no file, in expression starting on line 0
false
```