### PR TITLE
fix warning from overriding Base.==

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -123,6 +123,11 @@ end
 for op in (:+, :-, :*, :/, :%, :÷, :&, :|, :^, :<<, :>>, :(>>>),
            :(==), :<, :>, :<=, :>=,
            :scalarmin, :scalarmax)
+
+    if method_exists(getfield(Base, op), Tuple{Nullable, Nullable})
+        continue
+    end
+
     @eval begin
         @inline function $op{S,T}(x::Nullable{S}, y::Nullable{T})
             R = promote_op(@functorize($op), S, T)


### PR DESCRIPTION
Should fix this:
```
WARNING: Method definition ==(Base.Nullable{S}, Base.Nullable{T}) in module Base at nullable.jl:244 overwritten in module NullableArrays at /home/shashi/.julia/v0.6/NullableArrays/src/operators.jl:128.
```